### PR TITLE
feat: add pantry item modal and alert-aware pantry updates

### DIFF
--- a/src/features/pantry/components/PantryItemModal.tsx
+++ b/src/features/pantry/components/PantryItemModal.tsx
@@ -1,0 +1,292 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from 'sonner';
+import { useAuth } from '@/features/auth/AuthContext';
+import UnifiedPantryInput from './UnifiedPantryInput';
+import type { CreatePantryItemData, PantryItem, UpdatePantryItemData } from '../types';
+
+export type PantryItemModalMode = 'create' | 'edit';
+
+interface PantryItemModalProps {
+  open: boolean;
+  mode: PantryItemModalMode;
+  categories: Array<{ id: string; name: string }>;
+  onClose: () => void;
+  onSubmit: (payload: CreatePantryItemData | UpdatePantryItemData) => Promise<void>;
+  item?: PantryItem | null;
+}
+
+type FormState = {
+  ingredientName: string;
+  quantity: string;
+  unit: string;
+  categoryId: string;
+  expiryDate: string;
+  minStock: string;
+  notes: string;
+};
+
+const defaultFormState: FormState = {
+  ingredientName: '',
+  quantity: '',
+  unit: '',
+  categoryId: '',
+  expiryDate: '',
+  minStock: '',
+  notes: '',
+};
+
+const quantityToInput = (value: number | null | undefined) =>
+  typeof value === 'number' && !Number.isNaN(value) ? String(value) : '';
+
+export const PantryItemModal: React.FC<PantryItemModalProps> = ({
+  open,
+  mode,
+  categories,
+  onClose,
+  onSubmit,
+  item,
+}) => {
+  const { user } = useAuth();
+  const [formState, setFormState] = useState<FormState>(defaultFormState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setFormState(defaultFormState);
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (mode === 'edit' && item) {
+      setFormState({
+        ingredientName: item.ingredient?.name || '',
+        quantity: quantityToInput(item.quantity),
+        unit: item.unit || '',
+        categoryId: item.category_id || '',
+        expiryDate: item.expiry_date ? item.expiry_date.split('T')[0] : '',
+        minStock: quantityToInput(item.min_stock),
+        notes: item.notes || '',
+      });
+    } else if (mode === 'create') {
+      setFormState(defaultFormState);
+    }
+  }, [open, mode, item]);
+
+  const categoryOptions = useMemo(() => categories ?? [], [categories]);
+
+  const handleParsedData = (data: CreatePantryItemData) => {
+    setFormState((prev) => ({
+      ...prev,
+      ingredientName: data.ingredient_name ?? prev.ingredientName,
+      quantity: data.quantity !== undefined && data.quantity !== null ? String(data.quantity) : prev.quantity,
+      unit: data.unit ?? prev.unit,
+      categoryId: data.category_id ?? prev.categoryId,
+      expiryDate: data.expiry_date ?? prev.expiryDate,
+    }));
+    toast.success('Datos parseados listos para editar.');
+  };
+
+  const handleSubmit = async () => {
+    if (isSubmitting) return;
+    if (!formState.ingredientName.trim()) {
+      toast.error('El nombre del ingrediente es obligatorio.');
+      return;
+    }
+
+    if (mode === 'create' && !user) {
+      toast.error('Debes iniciar sesión para añadir ítems.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      if (mode === 'create') {
+        const payload: CreatePantryItemData = {
+          ingredient_name: formState.ingredientName.trim(),
+          quantity: formState.quantity ? Number(formState.quantity) : 1,
+          unit: formState.unit ? formState.unit : null,
+          category_id: formState.categoryId || null,
+          expiry_date: formState.expiryDate || null,
+          notes: formState.notes ? formState.notes.trim() : null,
+          min_stock: formState.minStock ? Number(formState.minStock) : null,
+          user_id: user!.id,
+        };
+        await onSubmit(payload);
+        toast.success('Ítem añadido correctamente.');
+      } else if (mode === 'edit') {
+        const payload: UpdatePantryItemData = {
+          quantity: formState.quantity ? Number(formState.quantity) : null,
+          unit: formState.unit ? formState.unit : null,
+          category_id: formState.categoryId || null,
+          expiry_date: formState.expiryDate || null,
+          notes: formState.notes ? formState.notes.trim() : null,
+          min_stock: formState.minStock ? Number(formState.minStock) : null,
+        };
+        await onSubmit(payload);
+        toast.success('Cambios guardados.');
+      }
+      onClose();
+    } catch (error) {
+      console.error('[PantryItemModal] Error submitting pantry item:', error);
+      toast.error(error instanceof Error ? error.message : 'Ocurrió un error al guardar el ítem.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const title = mode === 'edit' ? 'Editar ítem de despensa' : 'Añadir ítem a la despensa';
+  const description =
+    mode === 'edit'
+      ? 'Actualiza los detalles del producto seleccionado.'
+      : 'Puedes usar la entrada rápida para autocompletar los campos o llenarlos manualmente.';
+
+  return (
+    <Dialog open={open} onOpenChange={(value) => (!value ? onClose() : undefined)}>
+      <DialogContent className="max-w-lg sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        {mode === 'create' && (
+          <div className="rounded-md border border-dashed border-muted-foreground/30 bg-muted/40 p-3 sm:p-4">
+            <p className="text-sm text-muted-foreground mb-2">
+              Usa el campo de entrada rápida para parsear frases como "2 litros de leche" y rellenar el formulario.
+            </p>
+            <UnifiedPantryInput
+              mode="modal"
+              onItemAdded={() => undefined}
+              availableCategories={categoryOptions}
+              onEditRequest={handleParsedData}
+            />
+          </div>
+        )}
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="pantry-modal-name">Nombre</Label>
+            <Input
+              id="pantry-modal-name"
+              value={formState.ingredientName}
+              onChange={(event) =>
+                setFormState((prev) => ({ ...prev, ingredientName: event.target.value }))
+              }
+              placeholder="Ej: Tomates, harina, leche..."
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="grid gap-2">
+              <Label htmlFor="pantry-modal-quantity">Cantidad</Label>
+              <Input
+                id="pantry-modal-quantity"
+                type="number"
+                min={0}
+                value={formState.quantity}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, quantity: event.target.value }))
+                }
+                placeholder="1"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="pantry-modal-unit">Unidad</Label>
+              <Input
+                id="pantry-modal-unit"
+                value={formState.unit}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, unit: event.target.value }))
+                }
+                placeholder="kg, L, unidades..."
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="pantry-modal-category">Categoría</Label>
+            <Select
+              value={formState.categoryId || undefined}
+              onValueChange={(value) => setFormState((prev) => ({ ...prev, categoryId: value }))}
+            >
+              <SelectTrigger id="pantry-modal-category">
+                <SelectValue placeholder="Selecciona una categoría" />
+              </SelectTrigger>
+              <SelectContent>
+                {categoryOptions.map((category) => (
+                  <SelectItem key={category.id} value={category.id}>
+                    {category.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="grid gap-2">
+              <Label htmlFor="pantry-modal-expiry">Fecha de caducidad</Label>
+              <Input
+                id="pantry-modal-expiry"
+                type="date"
+                value={formState.expiryDate}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, expiryDate: event.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="pantry-modal-min-stock">Stock mínimo</Label>
+              <Input
+                id="pantry-modal-min-stock"
+                type="number"
+                min={0}
+                value={formState.minStock}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, minStock: event.target.value }))
+                }
+                placeholder="Opcional"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="pantry-modal-notes">Notas</Label>
+            <Textarea
+              id="pantry-modal-notes"
+              value={formState.notes}
+              onChange={(event) =>
+                setFormState((prev) => ({ ...prev, notes: event.target.value }))
+              }
+              placeholder="Información adicional, ubicación, etc."
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            Cancelar
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? 'Guardando...' : mode === 'edit' ? 'Guardar cambios' : 'Añadir ítem'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PantryItemModal;

--- a/src/features/pantry/components/UnifiedPantryInput.tsx
+++ b/src/features/pantry/components/UnifiedPantryInput.tsx
@@ -18,16 +18,20 @@ const BarcodeScanner = lazy(() => import('./barcode/BarcodeScanner'));
 // const VoiceInput = lazy(() => import('./voice/VoiceInput')); // Comentado para prueba
 import VoiceInput from './voice/VoiceInput'; // Importación directa para prueba
 
+type UnifiedInputMode = 'pantry' | 'modal';
+
 interface UnifiedPantryInputProps {
   onItemAdded: () => void;
   availableCategories: Array<{ id: string; name: string }>;
   onEditRequest?: (data: CreatePantryItemData) => void;
+  mode?: UnifiedInputMode;
 }
 
 const UnifiedPantryInput: React.FC<UnifiedPantryInputProps> = ({
   onItemAdded,
   availableCategories,
   onEditRequest,
+  mode = 'pantry',
 }) => {
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -88,6 +92,20 @@ const UnifiedPantryInput: React.FC<UnifiedPantryInputProps> = ({
   };
 
   const handleConfirmAdd = async (itemDataFromPreview: CreatePantryItemData, addAnother: boolean) => {
+    if (mode === 'modal') {
+      try {
+        onEditRequest?.(itemDataFromPreview);
+        setParseResultForPreview(null);
+        if (!addAnother) {
+          setInputValue('');
+        }
+      } catch (error) {
+        console.error('[UnifiedPantryInput] Error sending parsed data to modal:', error);
+        toast.error('No se pudo preparar la edición del ítem.');
+      }
+      return;
+    }
+
     if (!user) {
       toast.error("Error: Usuario no autenticado.");
       return;
@@ -107,9 +125,9 @@ const UnifiedPantryInput: React.FC<UnifiedPantryInputProps> = ({
       onItemAdded();
     } catch (error) {
       console.error("Error adding item from unified input:", error);
-      const errorMessage = (error instanceof Error && error.message) 
-         ? error.message 
-         : (typeof error === 'object' && error !== null && 'message' in error) 
+      const errorMessage = (error instanceof Error && error.message)
+         ? error.message
+         : (typeof error === 'object' && error !== null && 'message' in error)
          ? String(error.message)
          : "Error al añadir el ítem.";
       toast.error(errorMessage);

--- a/src/features/pantry/pantryService.test.ts
+++ b/src/features/pantry/pantryService.test.ts
@@ -3,255 +3,320 @@ import {
   addPantryItem,
   updatePantryItem,
   deletePantryItem,
-  // getLowStockItems, // TODO: Re-enable/implement getLowStockItems tests
+  deleteMultiplePantryItems,
+  toggleFavoritePantryItem,
+  clearPantry,
+  fetchLowStockItems,
 } from './pantryService';
-// Importar SOLO el mock de supabase
 import { supabase } from '@/lib/supabaseClient';
+import { findOrCreateIngredient, normalizeIngredientName } from '../ingredients/ingredientService';
+import { inferCategory } from '../shopping-list/lib/categoryInference';
 
-// Mockear el módulo
 jest.mock('@/lib/supabaseClient');
+jest.mock('../ingredients/ingredientService', () => ({
+  findOrCreateIngredient: jest.fn(),
+  normalizeIngredientName: jest.fn((name: string) => name),
+}));
+jest.mock('../shopping-list/lib/categoryInference', () => ({
+  inferCategory: jest.fn(),
+}));
 
-// Acceder a los mocks directamente desde el objeto supabase importado
 const mockGetUser = supabase.auth.getUser as jest.Mock;
 const mockFrom = supabase.from as jest.Mock;
-// No definir mocks encadenados aquí, se configurarán por prueba
+const mockFindOrCreateIngredient = findOrCreateIngredient as jest.Mock;
+const mockNormalizeIngredientName = normalizeIngredientName as jest.Mock;
+const mockInferCategory = inferCategory as jest.Mock;
 
-// Mock de usuario
 const mockUser = { id: 'pantry-user-456', email: 'pantry@test.com' };
 
 describe('pantryService', () => {
-
   beforeEach(() => {
-    jest.resetAllMocks(); // Resetear todos los mocks completamente
-    // Configurar mock de usuario por defecto para CADA prueba
+    jest.resetAllMocks();
     mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockFindOrCreateIngredient.mockResolvedValue({ id: 'ing-1', name: 'Test Ingredient' });
+    mockInferCategory.mockResolvedValue(null);
+    mockNormalizeIngredientName.mockImplementation((name: string) => `normalized-${name}`);
   });
 
-  // --- getPantryItems ---
   describe('getPantryItems', () => {
     it('should fetch pantry items for the current user', async () => {
-      const mockPantryData = [{ id: 'p1', name: 'Milk', quantity: 1, unit: 'L', user_id: mockUser.id }];
-      // Configurar cadena: from -> select -> eq -> order -> then
-      const mockOrder = jest.fn().mockResolvedValueOnce({ data: mockPantryData, error: null });
+      const mockData = [
+        {
+          id: 'p1',
+          quantity: 1,
+          unit: 'u',
+          user_id: mockUser.id,
+          ingredients: { id: 'ing-1', name: 'Milk', image_url: 'milk.png' },
+          categories: { id: 'cat-1', name: 'Lácteos', icon_name: 'milk' },
+        },
+      ];
+
+      const mockOrder = jest.fn().mockResolvedValue({ data: mockData, error: null });
       const mockEq = jest.fn(() => ({ order: mockOrder }));
       const mockSelect = jest.fn(() => ({ eq: mockEq }));
-      mockFrom.mockImplementationOnce(() => ({ select: mockSelect }));
+      mockFrom.mockReturnValueOnce({ select: mockSelect });
 
       const items = await getPantryItems();
 
-      expect(items).toEqual(mockPantryData);
       expect(mockFrom).toHaveBeenCalledWith('pantry_items');
-      expect(mockSelect).toHaveBeenCalledWith('*');
+      expect(mockSelect).toHaveBeenCalledWith(expect.stringContaining('ingredients'));
       expect(mockEq).toHaveBeenCalledWith('user_id', mockUser.id);
-      expect(mockOrder).toHaveBeenCalledWith('created_at', { ascending: false });
+      expect(items[0].ingredient?.name).toBe('normalized-Milk');
+      expect(items[0].category?.name).toBe('Lácteos');
     });
 
-    it('should throw error if user is not authenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null }); 
-      await expect(getPantryItems()).rejects.toThrow('Usuario no autenticado');
-    });
-
-    it('should throw error if fetch fails', async () => {
-      // Configurar cadena para fallo
-      const mockOrder = jest.fn().mockResolvedValueOnce({ data: null, error: new Error('DB Error') });
+    it('should throw an error when supabase fails', async () => {
+      const mockOrder = jest.fn().mockResolvedValue({ data: null, error: new Error('DB Error') });
       const mockEq = jest.fn(() => ({ order: mockOrder }));
       const mockSelect = jest.fn(() => ({ eq: mockEq }));
-      mockFrom.mockImplementationOnce(() => ({ select: mockSelect }));
+      mockFrom.mockReturnValueOnce({ select: mockSelect });
+
       await expect(getPantryItems()).rejects.toThrow('No se pudieron cargar los ítems de la despensa.');
     });
   });
 
-  // --- addPantryItem ---
   describe('addPantryItem', () => {
-    const newItemData = { ingredient_name: 'Eggs', quantity: 12, unit: 'unit' }; // Usar ingredient_name
-    const addedItemDB = { id: 'p-new', user_id: mockUser.id, ...newItemData, ingredient: { name: newItemData.ingredient_name } }; // Usar ingredient_name
+    it('should upsert a new item and return it', async () => {
+      const newItemData = {
+        ingredient_name: 'Eggs',
+        quantity: 12,
+        unit: 'u',
+        user_id: mockUser.id,
+      };
 
-    it('should insert a new item and return it', async () => {
-      // Configurar cadena: from -> insert -> select -> single -> then
-      const mockSingle = jest.fn().mockResolvedValueOnce({ data: addedItemDB, error: null }); 
+      mockFindOrCreateIngredient.mockResolvedValue({ id: 'ing-eggs', name: 'Eggs' });
+      mockInferCategory.mockResolvedValue('cat-eggs');
+
+      const dbItem = {
+        id: 'p-new',
+        quantity: 12,
+        unit: 'u',
+        user_id: mockUser.id,
+        ingredient_id: 'ing-eggs',
+        ingredients: { id: 'ing-eggs', name: 'Eggs', image_url: null },
+        categories: { id: 'cat-eggs', name: 'Huevos', icon_name: 'egg' },
+      };
+
+      const mockSingle = jest.fn().mockResolvedValue({ data: dbItem, error: null });
       const mockSelect = jest.fn(() => ({ single: mockSingle }));
-      const mockInsert = jest.fn(() => ({ select: mockSelect }));
-      mockFrom.mockImplementationOnce(() => ({ insert: mockInsert }));
+      const mockUpsert = jest.fn(() => ({ select: mockSelect }));
+      mockFrom.mockReturnValueOnce({ upsert: mockUpsert });
 
-      const result = await addPantryItem(newItemData);
+      const result = await addPantryItem(newItemData as any);
 
-      expect(result).toEqual(addedItemDB);
-      expect(mockFrom).toHaveBeenCalledWith('pantry_items');
-      expect(mockInsert).toHaveBeenCalledWith({ ...newItemData, user_id: mockUser.id });
-    });
-    
-    it('should handle null quantity correctly', async () => {
-       const newItemNullQty = { ingredient_name: 'Flour', quantity: null, unit: 'kg' }; // Usar ingredient_name
-       const addedItemNullQtyDB = { id: 'p-null', user_id: mockUser.id, name: 'Flour', quantity: null, unit: 'kg', ingredient: { name: 'Flour' } }; // Simular 'ingredient' poblado
-       const mockSingle = jest.fn().mockResolvedValueOnce({ data: addedItemNullQtyDB, error: null }); 
-       const mockSelect = jest.fn(() => ({ single: mockSingle }));
-       const mockInsert = jest.fn(() => ({ select: mockSelect }));
-       mockFrom.mockImplementationOnce(() => ({ insert: mockInsert }));
-
-       const result = await addPantryItem(newItemNullQty);
-       expect(result.quantity).toBeNull();
-       expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ quantity: null }));
-    });
-    
-    it('should handle invalid quantity string as null', async () => {
-       const newItemInvalidQty = { ingredient_name: 'Sugar', quantity: 'abc' as any, unit: 'kg' }; // Usar ingredient_name
-       const addedItemInvalidQtyDB = { id: 'p-invalid', user_id: mockUser.id, name: 'Sugar', quantity: null, unit: 'kg', ingredient: { name: 'Sugar' } }; // Simular 'ingredient' poblado
-       const mockSingle = jest.fn().mockResolvedValueOnce({ data: addedItemInvalidQtyDB, error: null }); 
-       const mockSelect = jest.fn(() => ({ single: mockSingle }));
-       const mockInsert = jest.fn(() => ({ select: mockSelect }));
-       mockFrom.mockImplementationOnce(() => ({ insert: mockInsert }));
-
-       const result = await addPantryItem(newItemInvalidQty);
-       expect(result.quantity).toBeNull();
-       expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ quantity: null }));
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: mockUser.id,
+          ingredient_id: 'ing-eggs',
+          quantity: 12,
+          unit: 'u',
+        }),
+        expect.objectContaining({ onConflict: expect.stringContaining('user_id') }),
+      );
+      expect(result.category?.id).toBe('cat-eggs');
+      expect(mockNormalizeIngredientName).toHaveBeenCalledWith('Eggs', 12);
     });
 
-    it('should throw error if user is not authenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null }); 
-      await expect(addPantryItem(newItemData)).rejects.toThrow('Usuario no autenticado'); 
-    });
+    it('should throw when upsert fails', async () => {
+      const newItemData = {
+        ingredient_name: 'Sugar',
+        quantity: 1,
+        user_id: mockUser.id,
+      };
 
-    it('should throw error if insert fails', async () => {
-      const mockSingle = jest.fn().mockResolvedValueOnce({ data: null, error: new Error('Insert Fail') });
+      const mockSingle = jest.fn().mockResolvedValue({ data: null, error: new Error('Insert Fail') });
       const mockSelect = jest.fn(() => ({ single: mockSingle }));
-      const mockInsert = jest.fn(() => ({ select: mockSelect }));
-      mockFrom.mockImplementationOnce(() => ({ insert: mockInsert }));
-      await expect(addPantryItem(newItemData)).rejects.toThrow('No se pudo añadir el ítem a la despensa.');
+      const mockUpsert = jest.fn(() => ({ select: mockSelect }));
+      mockFrom.mockReturnValueOnce({ upsert: mockUpsert });
+
+      await expect(addPantryItem(newItemData as any)).rejects.toThrow(
+        'No se pudo guardar el ítem en la despensa.',
+      );
     });
   });
 
-  // --- updatePantryItem ---
   describe('updatePantryItem', () => {
-     const itemId = 'p-update';
-     const updates = { quantity: 5 };
-     const updatedItemDB = { id: itemId, name: 'Milk', quantity: 5, unit: 'L', user_id: mockUser.id, ingredient: { name: 'Milk' } }; // Simular 'ingredient' poblado
+    it('should update an existing item', async () => {
+      const updatedRow = {
+        id: 'p-update',
+        quantity: 5,
+        unit: 'kg',
+        user_id: mockUser.id,
+        ingredients: { id: 'ing-1', name: 'Flour', image_url: null },
+        categories: { id: 'cat-1', name: 'Básicos', icon_name: 'box' },
+      };
 
-     it('should update an existing item and return it', async () => {
-       // Configurar cadena: from -> update -> eq -> select -> single -> then
-       const mockSingle = jest.fn().mockResolvedValueOnce({ data: updatedItemDB, error: null }); 
-       const mockSelect = jest.fn(() => ({ single: mockSingle }));
-       const mockEq = jest.fn(() => ({ select: mockSelect }));
-       const mockUpdate = jest.fn(() => ({ eq: mockEq }));
-       mockFrom.mockImplementationOnce(() => ({ update: mockUpdate }));
+      const mockSingle = jest.fn().mockResolvedValue({ data: updatedRow, error: null });
+      const mockSelect = jest.fn(() => ({ single: mockSingle }));
+      const secondEq = jest.fn(() => ({ select: mockSelect }));
+      const firstEq = jest.fn(() => ({ eq: secondEq }));
+      const mockUpdate = jest.fn(() => ({ eq: firstEq }));
+      mockFrom.mockReturnValueOnce({ update: mockUpdate });
 
-       const result = await updatePantryItem(itemId, updates);
+      const result = await updatePantryItem('p-update', { quantity: 5 });
 
-       expect(result).toEqual(updatedItemDB);
-       expect(mockFrom).toHaveBeenCalledWith('pantry_items');
-       expect(mockUpdate).toHaveBeenCalledWith(updates);
-       expect(mockEq).toHaveBeenCalledWith('id', itemId);
-     });
-     
-     it('should handle null quantity update', async () => {
-        const nullUpdates = { quantity: null };
-        const mockSingle = jest.fn().mockResolvedValueOnce({ data: { ...updatedItemDB, quantity: null }, error: null });
-        const mockSelect = jest.fn(() => ({ single: mockSingle }));
-        const mockEq = jest.fn(() => ({ select: mockSelect }));
-        const mockUpdate = jest.fn(() => ({ eq: mockEq }));
-        mockFrom.mockImplementationOnce(() => ({ update: mockUpdate }));
-        
-        const result = await updatePantryItem(itemId, nullUpdates);
-        expect(result.quantity).toBeNull();
-        expect(mockUpdate).toHaveBeenCalledWith({ quantity: null });
-     });
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ quantity: 5 }));
+      expect(secondEq).toHaveBeenCalledWith('user_id', mockUser.id);
+      expect(result.ingredient?.name).toBe('normalized-Flour');
+    });
 
-     it('should throw error if user is not authenticated', async () => {
-       mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null }); 
-       await expect(updatePantryItem(itemId, updates)).rejects.toThrow('Usuario no autenticado'); 
-     });
+    it('should throw when update fails', async () => {
+      const mockSingle = jest.fn().mockResolvedValue({ data: null, error: new Error('Update Fail') });
+      const mockSelect = jest.fn(() => ({ single: mockSingle }));
+      const secondEq = jest.fn(() => ({ select: mockSelect }));
+      const firstEq = jest.fn(() => ({ eq: secondEq }));
+      const mockUpdate = jest.fn(() => ({ eq: firstEq }));
+      mockFrom.mockReturnValueOnce({ update: mockUpdate });
 
-     it('should throw error if update fails', async () => {
-       const mockSingle = jest.fn().mockResolvedValueOnce({ data: null, error: new Error('Update Fail') });
-       const mockSelect = jest.fn(() => ({ single: mockSingle }));
-       const mockEq = jest.fn(() => ({ select: mockSelect }));
-       const mockUpdate = jest.fn(() => ({ eq: mockEq }));
-       mockFrom.mockImplementationOnce(() => ({ update: mockUpdate }));
-       await expect(updatePantryItem(itemId, updates)).rejects.toThrow('No se pudo actualizar el ítem.');
-     });
+      await expect(updatePantryItem('p-update', { quantity: 3 })).rejects.toThrow(
+        'No se pudo actualizar el ítem.',
+      );
+    });
   });
 
-  // --- deletePantryItem ---
   describe('deletePantryItem', () => {
-     it('should delete an item', async () => {
-       // Configurar cadena: from -> delete -> eq -> then
-       const mockThen = jest.fn().mockResolvedValueOnce({ error: null }); 
-       const mockEq = jest.fn(() => ({ then: mockThen }));
-       const mockDelete = jest.fn(() => ({ eq: mockEq }));
-       mockFrom.mockImplementationOnce(() => ({ delete: mockDelete }));
+    it('should delete an item', async () => {
+      const secondEq = jest.fn().mockResolvedValue({ error: null });
+      const firstEq = jest.fn(() => ({ eq: secondEq }));
+      const mockDelete = jest.fn(() => ({ eq: firstEq }));
+      mockFrom.mockReturnValueOnce({ delete: mockDelete });
 
-       await expect(deletePantryItem('p-delete')).resolves.toBeUndefined();
-       expect(mockFrom).toHaveBeenCalledWith('pantry_items');
-       expect(mockDelete).toHaveBeenCalled();
-       expect(mockEq).toHaveBeenCalledWith('id', 'p-delete');
-     });
+      await expect(deletePantryItem('p-delete')).resolves.toBeUndefined();
+      expect(firstEq).toHaveBeenCalledWith('id', 'p-delete');
+      expect(secondEq).toHaveBeenCalledWith('user_id', mockUser.id);
+    });
 
-     it('should throw error if user is not authenticated', async () => {
-       mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null }); 
-       await expect(deletePantryItem('p-delete-fail')).rejects.toThrow('Usuario no autenticado'); 
-     });
+    it('should throw when delete fails', async () => {
+      const secondEq = jest.fn().mockResolvedValue({ error: new Error('Delete Fail') });
+      const firstEq = jest.fn(() => ({ eq: secondEq }));
+      const mockDelete = jest.fn(() => ({ eq: firstEq }));
+      mockFrom.mockReturnValueOnce({ delete: mockDelete });
 
-     it('should throw error if delete fails', async () => {
-        const mockThen = jest.fn().mockResolvedValueOnce({ error: new Error('Delete Fail') }); 
-        const mockEq = jest.fn(() => ({ then: mockThen }));
-        const mockDelete = jest.fn(() => ({ eq: mockEq }));
-        mockFrom.mockImplementationOnce(() => ({ delete: mockDelete }));
-       await expect(deletePantryItem('p-delete-fail')).rejects.toThrow('No se pudo eliminar el ítem.');
-     });
+      await expect(deletePantryItem('p-delete')).rejects.toThrow('No se pudo eliminar el ítem.');
+    });
   });
 
-  // --- getLowStockItems --- // TODO: Re-enable/implement getLowStockItems tests
-  // describe('getLowStockItems', () => {
-  //    it('should fetch items with quantity <= threshold', async () => {
-  //      const mockLowStockData = [{ id: 'p-low', name: 'Salt', quantity: 0, user_id: mockUser.id }];
-  //      // Configurar cadena: from -> select -> eq -> lte -> order -> then
-  //      const mockThen = jest.fn().mockResolvedValueOnce({ data: mockLowStockData, error: null });
-  //      const mockOrder = jest.fn(() => ({ then: mockThen }));
-  //      const mockLte = jest.fn(() => ({ order: mockOrder }));
-  //      const mockEq = jest.fn(() => ({ lte: mockLte }));
-  //      const mockSelect = jest.fn(() => ({ eq: mockEq }));
-  //      mockFrom.mockImplementationOnce(() => ({ select: mockSelect }));
-  //
-  //      const items = await getLowStockItems(1); // Threshold 1
-  //
-  //      expect(items).toEqual(mockLowStockData);
-  //      expect(mockFrom).toHaveBeenCalledWith('pantry_items');
-  //      expect(mockSelect).toHaveBeenCalledWith('*');
-  //      expect(mockEq).toHaveBeenCalledWith('user_id', mockUser.id);
-  //      expect(mockLte).toHaveBeenCalledWith('quantity', 1);
-  //      expect(mockOrder).toHaveBeenCalledWith('name', { ascending: true });
-  //    });
-  //
-  //    it('should use default threshold of 1 if not provided', async () => {
-  //       const mockThen = jest.fn().mockResolvedValueOnce({ data: [], error: null });
-  //       const mockOrder = jest.fn(() => ({ then: mockThen }));
-  //       const mockLte = jest.fn(() => ({ order: mockOrder }));
-  //       const mockEq = jest.fn(() => ({ lte: mockLte }));
-  //       const mockSelect = jest.fn(() => ({ eq: mockEq }));
-  //       mockFrom.mockImplementationOnce(() => ({ select: mockSelect }));
-  //
-  //       await getLowStockItems(); // Sin threshold
-  //       expect(mockLte).toHaveBeenCalledWith('quantity', 1); // Verifica threshold por defecto
-  //    });
-  //
-  //    it('should throw error if user is not authenticated', async () => {
-  //      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
-  //      await expect(getLowStockItems()).rejects.toThrow('Usuario no autenticado');
-  //    });
-  //
-  //    it('should throw error if fetch fails', async () => {
-  //       const mockThen = jest.fn().mockResolvedValueOnce({ data: null, error: new Error('Low Stock Fetch Fail') });
-  //       const mockOrder = jest.fn(() => ({ then: mockThen }));
-  //       const mockLte = jest.fn(() => ({ order: mockOrder }));
-  //       const mockEq = jest.fn(() => ({ lte: mockLte }));
-  //       const mockSelect = jest.fn(() => ({ eq: mockEq }));
-  //       mockFrom.mockImplementationOnce(() => ({ select: mockSelect }));
-  //       await expect(getLowStockItems()).rejects.toThrow('No se pudieron cargar los ítems con bajo stock.');
-  //    });
-  // });
+  describe('deleteMultiplePantryItems', () => {
+    it('should delete multiple items', async () => {
+      const eqMock = jest.fn().mockResolvedValue({ error: null });
+      const inMock = jest.fn(() => ({ eq: eqMock }));
+      const deleteMock = jest.fn(() => ({ in: inMock }));
+      mockFrom.mockReturnValueOnce({ delete: deleteMock });
 
+      await expect(deleteMultiplePantryItems(['a', 'b'])).resolves.toBeUndefined();
+      expect(deleteMock).toHaveBeenCalled();
+      expect(inMock).toHaveBeenCalledWith('id', ['a', 'b']);
+      expect(eqMock).toHaveBeenCalledWith('user_id', mockUser.id);
+    });
+
+    it('should throw on failure', async () => {
+      const eqMock = jest.fn().mockResolvedValue({ error: new Error('bulk delete fail') });
+      const inMock = jest.fn(() => ({ eq: eqMock }));
+      const deleteMock = jest.fn(() => ({ in: inMock }));
+      mockFrom.mockReturnValueOnce({ delete: deleteMock });
+
+      await expect(deleteMultiplePantryItems(['a'])).rejects.toThrow(
+        'No se pudieron eliminar los ítems seleccionados.',
+      );
+    });
+  });
+
+  describe('toggleFavoritePantryItem', () => {
+    it('should toggle favorite state', async () => {
+      const dbItem = {
+        id: 'fav-1',
+        is_favorite: true,
+        quantity: 1,
+        user_id: mockUser.id,
+        ingredients: { id: 'ing-1', name: 'Rice', image_url: null },
+        categories: null,
+      };
+
+      const mockSingle = jest.fn().mockResolvedValue({ data: dbItem, error: null });
+      const mockSelect = jest.fn(() => ({ single: mockSingle }));
+      const secondEq = jest.fn(() => ({ select: mockSelect }));
+      const firstEq = jest.fn(() => ({ eq: secondEq }));
+      const mockUpdate = jest.fn(() => ({ eq: firstEq }));
+      mockFrom.mockReturnValueOnce({ update: mockUpdate });
+
+      const result = await toggleFavoritePantryItem('fav-1', true);
+
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ is_favorite: true }));
+      expect(secondEq).toHaveBeenCalledWith('user_id', mockUser.id);
+      expect(result?.ingredient?.name).toBe('normalized-Rice');
+    });
+
+    it('should throw on failure', async () => {
+      const mockSingle = jest.fn().mockResolvedValue({ data: null, error: new Error('toggle fail') });
+      const mockSelect = jest.fn(() => ({ single: mockSingle }));
+      const secondEq = jest.fn(() => ({ select: mockSelect }));
+      const firstEq = jest.fn(() => ({ eq: secondEq }));
+      const mockUpdate = jest.fn(() => ({ eq: firstEq }));
+      mockFrom.mockReturnValueOnce({ update: mockUpdate });
+
+      await expect(toggleFavoritePantryItem('fav-1', false)).rejects.toThrow(
+        'No se pudo actualizar el estado de favorito.',
+      );
+    });
+  });
+
+  describe('clearPantry', () => {
+    it('should clear all items for the user', async () => {
+      const eqMock = jest.fn().mockResolvedValue({ error: null });
+      const deleteMock = jest.fn(() => ({ eq: eqMock }));
+      mockFrom.mockReturnValueOnce({ delete: deleteMock });
+
+      await expect(clearPantry()).resolves.toBeUndefined();
+      expect(eqMock).toHaveBeenCalledWith('user_id', mockUser.id);
+    });
+
+    it('should throw when deletion fails', async () => {
+      const eqMock = jest.fn().mockResolvedValue({ error: new Error('clear fail') });
+      const deleteMock = jest.fn(() => ({ eq: eqMock }));
+      mockFrom.mockReturnValueOnce({ delete: deleteMock });
+
+      await expect(clearPantry()).rejects.toThrow('No se pudo vaciar la despensa.');
+    });
+  });
+
+  describe('fetchLowStockItems', () => {
+    it('should return items with quantity under min_stock', async () => {
+      const mockRow = {
+        id: 'low-1',
+        quantity: 1,
+        min_stock: 2,
+        user_id: mockUser.id,
+        ingredients: { id: 'ing-1', name: 'Beans', image_url: null },
+        categories: null,
+      };
+
+      const mockOrder = jest.fn().mockResolvedValue({ data: [mockRow], error: null });
+      const mockNot = jest.fn(() => ({ order: mockOrder }));
+      const mockEq = jest.fn(() => ({ not: mockNot }));
+      const mockSelect = jest.fn(() => ({ eq: mockEq }));
+      mockFrom.mockReturnValueOnce({ select: mockSelect });
+
+      const items = await fetchLowStockItems();
+
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('low-1');
+    });
+
+    it('should throw when query fails', async () => {
+      const mockOrder = jest.fn().mockResolvedValue({ data: null, error: new Error('low stock fail') });
+      const mockNot = jest.fn(() => ({ order: mockOrder }));
+      const mockEq = jest.fn(() => ({ not: mockNot }));
+      const mockSelect = jest.fn(() => ({ eq: mockEq }));
+      mockFrom.mockReturnValueOnce({ select: mockSelect });
+
+      await expect(fetchLowStockItems()).rejects.toThrow(
+        'No se pudieron cargar los ítems con bajo stock.',
+      );
+    });
+  });
 });
 
-// Mock console
+// Quiet console noise in test output
 global.console = {
   ...console,
   log: jest.fn(),

--- a/src/features/pantry/pantryService.ts
+++ b/src/features/pantry/pantryService.ts
@@ -1,52 +1,87 @@
 import { supabase } from '../../lib/supabaseClient';
-import { PantryItem, CreatePantryItemData, UpdatePantryItemData, Category } from './types';
-import { findOrCreateIngredient, normalizeIngredientName } from '../ingredients/ingredientService';
+import {
+  PantryItem,
+  CreatePantryItemData,
+  UpdatePantryItemData,
+  Category,
+} from './types';
+import {
+  findOrCreateIngredient,
+  normalizeIngredientName,
+} from '../ingredients/ingredientService';
 import { inferCategory } from '../shopping-list/lib/categoryInference';
+
+const PANTRY_SELECT =
+  '*, is_favorite, ingredients(id, name, image_url), categories(id, name, icon_name)';
+
+const mapPantryRow = (row: any): PantryItem => ({
+  ...row,
+  ingredient: row.ingredients
+    ? {
+        id: row.ingredients.id,
+        name: normalizeIngredientName(row.ingredients.name, row.quantity ?? 1),
+        image_url: row.ingredients.image_url,
+      }
+    : null,
+  category: row.categories
+    ? {
+        id: row.categories.id,
+        name: row.categories.name,
+        icon_name: row.categories.icon_name,
+      }
+    : null,
+  ingredients: undefined,
+  categories: undefined,
+});
+
+const getAuthenticatedUserId = async (): Promise<string> => {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user) {
+    throw new Error('Usuario no autenticado');
+  }
+  return user.id;
+};
+
+const resolveUserId = async (explicitUserId?: string) => {
+  if (explicitUserId) return explicitUserId;
+  return getAuthenticatedUserId();
+};
 
 /**
  * Obtiene todos los items de la despensa para el usuario actual.
  */
 export const getPantryItems = async (): Promise<PantryItem[]> => {
-  const { data: { user }, error: authError } = await supabase.auth.getUser();
-  if (authError || !user) throw new Error("Usuario no autenticado");
+  const userId = await getAuthenticatedUserId();
 
   const { data, error } = await supabase
     .from('pantry_items')
-    .select('*, is_favorite, ingredients(id, name, image_url), categories(id, name, icon_name)') // Especificar columnas y añadir nuevas
-    .eq('user_id', user.id)
+    .select(PANTRY_SELECT)
+    .eq('user_id', userId)
     .order('created_at', { ascending: false });
 
-  if (error) throw error;
+  if (error) {
+    console.error('[getPantryItems] Supabase error:', error);
+    throw new Error('No se pudieron cargar los ítems de la despensa.');
+  }
 
-  return (data || []).map(item => ({
-    ...item,
-    // Mapear datos de ingredientes y categorías explícitamente
-    ingredient: item.ingredients ? {
-      id: item.ingredients.id, // Incluir ID si es necesario
-      name: normalizeIngredientName(item.ingredients.name, item.quantity ?? 1),
-      image_url: item.ingredients.image_url // Añadir image_url
-    } : null,
-    category: item.categories ? {
-      id: item.categories.id, // Incluir ID si es necesario
-      name: item.categories.name,
-      icon_name: item.categories.icon_name // Añadir icon_name
-      // Añadir color si se usa en la UI directamente desde aquí
-    } : null,
-    ingredients: undefined,
-    categories: undefined
-  }));
+  return (data ?? []).map(mapPantryRow);
 };
 
 /**
  * Obtiene todas las categorías disponibles.
  */
 export const getCategories = async (): Promise<Category[]> => {
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   const orFilter = user ? `is_default.eq.true,user_id.eq.${user.id}` : 'is_default.eq.true';
 
   const { data, error } = await supabase
     .from('categories')
-    .select('*, icon_name') // Añadir icon_name
+    .select('*, icon_name')
     .or(orFilter)
     .order('is_default', { ascending: false })
     .order('order', { ascending: true });
@@ -56,20 +91,17 @@ export const getCategories = async (): Promise<Category[]> => {
 };
 
 /**
- * Añade un nuevo item a la despensa.
+ * Añade o actualiza un item en la despensa usando un upsert transaccional.
  */
 export const addPantryItem = async (itemData: CreatePantryItemData): Promise<PantryItem> => {
-  if (!itemData.user_id) {
-     console.error("[addPantryItem Service] user_id falta en itemData:", itemData);
-     throw new Error("Falta user_id para añadir el item a la despensa.");
-  }
+  const userId = await resolveUserId(itemData.user_id);
 
   const ingredient = await findOrCreateIngredient(
     itemData.ingredient_name,
-    itemData.quantity ?? 1
+    itemData.quantity ?? 1,
   );
-  
-  let finalCategoryId = itemData.category_id;
+
+  let finalCategoryId = itemData.category_id ?? null;
   if (!finalCategoryId && ingredient?.name) {
     try {
       const inferredCategory = await inferCategory(ingredient.name);
@@ -77,58 +109,46 @@ export const addPantryItem = async (itemData: CreatePantryItemData): Promise<Pan
         finalCategoryId = inferredCategory;
       }
     } catch (error) {
-      console.error("Error during category inference:", error);
+      console.error('[addPantryItem] Error inferring category:', error);
     }
   }
 
-  // --- NUEVO LOG ---
-  console.log(`[addPantryItem Service] Attempting insert with user_id: ${itemData.user_id}`);
+  const payload = {
+    user_id: userId,
+    ingredient_id: ingredient.id,
+    quantity: itemData.quantity ?? 1,
+    unit: itemData.unit ?? null,
+    category_id: finalCategoryId,
+    expiry_date: itemData.expiry_date ?? null,
+    notes: itemData.notes ?? null,
+    min_stock: itemData.min_stock ?? null,
+  };
 
   const { data, error } = await supabase
     .from('pantry_items')
-    .insert({
-      user_id: itemData.user_id,
-      ingredient_id: ingredient.id,
-      name: itemData.ingredient_name,
-      quantity: itemData.quantity ?? 1,
-      unit: itemData.unit,
-      category_id: finalCategoryId,
-      expiry_date: itemData.expiry_date,
-      notes: itemData.notes,
+    .upsert(payload, {
+      onConflict: 'user_id,ingredient_id,unit',
+      ignoreDuplicates: false,
     })
-    .select('*, is_favorite, ingredients(id, name, image_url), categories(id, name, icon_name)') // Especificar columnas y añadir nuevas
+    .select(PANTRY_SELECT)
     .single();
 
-  if (error) {
-      // Añadir log más detallado del error de Supabase
-      console.error("[addPantryItem Service] Supabase insert error:", error);
-      throw error;
+  if (error || !data) {
+    console.error('[addPantryItem] Supabase upsert error:', error);
+    throw new Error('No se pudo guardar el ítem en la despensa.');
   }
-  if (!data) throw new Error("No se pudo crear el item");
 
-  return {
-    ...data,
-    ingredient: data.ingredients ? {
-      id: data.ingredients.id,
-      name: normalizeIngredientName(data.ingredients.name, data.quantity ?? 1),
-      image_url: data.ingredients.image_url
-    } : null,
-    category: data.categories ? {
-      id: data.categories.id,
-      name: data.categories.name,
-      icon_name: data.categories.icon_name
-    } : null,
-    ingredients: undefined,
-    categories: undefined
-  };
+  return mapPantryRow(data);
 };
 
 /**
  * Actualiza un item existente.
  */
-export const updatePantryItem = async (itemId: string, updateData: UpdatePantryItemData): Promise<PantryItem> => {
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error("Usuario no autenticado");
+export const updatePantryItem = async (
+  itemId: string,
+  updateData: UpdatePantryItemData,
+): Promise<PantryItem> => {
+  const userId = await getAuthenticatedUserId();
 
   const { data, error } = await supabase
     .from('pantry_items')
@@ -137,44 +157,34 @@ export const updatePantryItem = async (itemId: string, updateData: UpdatePantryI
       updated_at: new Date().toISOString(),
     })
     .eq('id', itemId)
-    .eq('user_id', user.id)
-    .select('*, is_favorite, ingredients(id, name, image_url), categories(id, name, icon_name)') // Especificar columnas y añadir nuevas
+    .eq('user_id', userId)
+    .select(PANTRY_SELECT)
     .single();
 
-  if (error) throw error;
-  if (!data) throw new Error("Item no encontrado");
+  if (error || !data) {
+    console.error('[updatePantryItem] Supabase error:', error);
+    throw new Error('No se pudo actualizar el ítem.');
+  }
 
-  return {
-    ...data,
-    ingredient: data.ingredients ? {
-      id: data.ingredients.id,
-      name: normalizeIngredientName(data.ingredients.name, data.quantity ?? 1),
-      image_url: data.ingredients.image_url
-    } : null,
-    category: data.categories ? {
-      id: data.categories.id,
-      name: data.categories.name,
-      icon_name: data.categories.icon_name
-    } : null,
-    ingredients: undefined,
-    categories: undefined
-  };
+  return mapPantryRow(data);
 };
 
 /**
  * Elimina un item de la despensa.
  */
 export const deletePantryItem = async (itemId: string): Promise<void> => {
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error("Usuario no autenticado");
+  const userId = await getAuthenticatedUserId();
 
   const { error } = await supabase
     .from('pantry_items')
     .delete()
     .eq('id', itemId)
-    .eq('user_id', user.id);
+    .eq('user_id', userId);
 
-  if (error) throw error;
+  if (error) {
+    console.error('[deletePantryItem] Supabase error:', error);
+    throw new Error('No se pudo eliminar el ítem.');
+  }
 };
 
 /**
@@ -183,99 +193,90 @@ export const deletePantryItem = async (itemId: string): Promise<void> => {
 export const deleteMultiplePantryItems = async (itemIds: string[]): Promise<void> => {
   if (!itemIds?.length) return;
 
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error("Usuario no autenticado");
+  const userId = await getAuthenticatedUserId();
 
   const { error } = await supabase
     .from('pantry_items')
     .delete()
     .in('id', itemIds)
-    .eq('user_id', user.id);
+    .eq('user_id', userId);
 
-  if (error) throw error;
+  if (error) {
+    console.error('[deleteMultiplePantryItems] Supabase error:', error);
+    throw new Error('No se pudieron eliminar los ítems seleccionados.');
+  }
 };
 
 /**
  * Cambia el estado de favorito de un item.
  */
-export const toggleFavoritePantryItem = async (itemId: string, isFavorite: boolean): Promise<PantryItem | null> => {
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error("Usuario no autenticado");
+export const toggleFavoritePantryItem = async (
+  itemId: string,
+  isFavorite: boolean,
+): Promise<PantryItem | null> => {
+  const userId = await getAuthenticatedUserId();
 
   const { data, error } = await supabase
     .from('pantry_items')
     .update({ is_favorite: isFavorite, updated_at: new Date().toISOString() })
     .eq('id', itemId)
-    .eq('user_id', user.id)
-    .select('*, is_favorite, ingredients(id, name, image_url), categories(id, name, icon_name)') // Especificar columnas y añadir nuevas
+    .eq('user_id', userId)
+    .select(PANTRY_SELECT)
     .single();
 
-  if (error) throw error;
-  if (!data) return null;
+  if (error) {
+    console.error('[toggleFavoritePantryItem] Supabase error:', error);
+    throw new Error('No se pudo actualizar el estado de favorito.');
+  }
 
-  return {
-    ...data,
-    ingredient: data.ingredients ? {
-      id: data.ingredients.id,
-      name: normalizeIngredientName(data.ingredients.name, data.quantity ?? 1),
-      image_url: data.ingredients.image_url
-    } : null,
-    category: data.categories ? {
-      id: data.categories.id,
-      name: data.categories.name,
-      icon_name: data.categories.icon_name
-    } : null,
-    ingredients: undefined,
-    categories: undefined
-  };
+  if (!data) {
+    return null;
+  }
+
+  return mapPantryRow(data);
 };
 
 /**
- * Elimina todos los items de la despensa.
+ * Elimina todos los items de la despensa del usuario.
  */
 export const clearPantry = async (): Promise<void> => {
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error("Usuario no autenticado");
+  const userId = await getAuthenticatedUserId();
 
   const { error } = await supabase
     .from('pantry_items')
     .delete()
-    .eq('user_id', user.id);
+    .eq('user_id', userId);
 
-  if (error) throw error;
+  if (error) {
+    console.error('[clearPantry] Supabase error:', error);
+    throw new Error('No se pudo vaciar la despensa.');
+  }
 };
 
 /**
  * Obtiene los items que están por debajo de su nivel mínimo de stock.
- * @returns Promise<PantryItem[]> Array de items con stock bajo
  */
 export const fetchLowStockItems = async (): Promise<PantryItem[]> => {
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error("Usuario no autenticado");
+  const userId = await getAuthenticatedUserId();
 
   const { data, error } = await supabase
     .from('pantry_items')
-    .select('*, is_favorite, ingredients(id, name, image_url), categories(id, name, icon_name)')
-    .eq('user_id', user.id)
+    .select(PANTRY_SELECT)
+    .eq('user_id', userId)
     .not('min_stock', 'is', null)
-    .lt('quantity', 'min_stock')
     .order('created_at', { ascending: false });
 
-  if (error) throw error;
+  if (error) {
+    console.error('[fetchLowStockItems] Supabase error:', error);
+    throw new Error('No se pudieron cargar los ítems con bajo stock.');
+  }
 
-  return (data || []).map(item => ({
-    ...item,
-    ingredient: item.ingredients ? {
-      id: item.ingredients.id,
-      name: normalizeIngredientName(item.ingredients.name, item.quantity ?? 1),
-      image_url: item.ingredients.image_url
-    } : null,
-    category: item.categories ? {
-      id: item.categories.id,
-      name: item.categories.name,
-      icon_name: item.categories.icon_name
-    } : null,
-    ingredients: undefined,
-    categories: undefined
-  }));
+  return (data ?? [])
+    .map(mapPantryRow)
+    .filter((item) =>
+      item.min_stock !== null && item.min_stock !== undefined
+        ? (typeof item.quantity === 'number' ? item.quantity : Number(item.quantity ?? 0)) <=
+          (typeof item.min_stock === 'number' ? item.min_stock : Number(item.min_stock ?? 0))
+        : false,
+    );
 };

--- a/src/stores/pantryStore.ts
+++ b/src/stores/pantryStore.ts
@@ -1,13 +1,17 @@
 import { create } from 'zustand';
+import { differenceInCalendarDays, parseISO, startOfDay } from 'date-fns';
+import { toast } from 'sonner';
 import {
   getPantryItems as getItemsService,
   addPantryItem as addItemService,
   updatePantryItem as updateItemService,
   deletePantryItem as deleteItemService,
   toggleFavoritePantryItem,
-  fetchLowStockItems as fetchLowStockItemsService
+  fetchLowStockItems as fetchLowStockItemsService,
 } from '../features/pantry/services/pantryService';
 import type { PantryItem, CreatePantryItemData, UpdatePantryItemData } from '../features/pantry/types';
+
+type PantryAlertTag = 'expired' | 'near-expiry' | 'low-stock';
 
 interface PantryState {
   items: PantryItem[];
@@ -16,13 +20,122 @@ interface PantryState {
   isLoadingLowStock: boolean;
   error: string | null;
   errorLowStock: string | null;
+  alertTags: Record<string, PantryAlertTag[]>;
+  autoFilters: PantryAlertTag[];
   fetchItems: () => Promise<void>;
   fetchLowStockItems: (threshold?: number) => Promise<void>;
   addItem: (itemData: CreatePantryItemData) => Promise<PantryItem | null>;
   updateItem: (itemId: string, updates: UpdatePantryItemData) => Promise<PantryItem | null>;
   deleteItem: (itemId: string) => Promise<boolean>;
   toggleFavorite: (itemId: string) => Promise<void>;
+  clearAutoFilters: () => void;
 }
+
+const NEAR_EXPIRY_THRESHOLD_DAYS = 3;
+const ALERT_PRIORITY: PantryAlertTag[] = ['expired', 'near-expiry', 'low-stock'];
+const alertHistory = new Set<string>();
+
+type ExpiryInfo = { status: Extract<PantryAlertTag, 'expired' | 'near-expiry'>; diff: number } | null;
+
+interface ItemAlertAnalysis {
+  tags: PantryAlertTag[];
+  expiryInfo: ExpiryInfo;
+}
+
+const safeParseDate = (value: string): Date | null => {
+  try {
+    const parsed = parseISO(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  } catch (error) {
+    console.warn('[pantryStore] Unable to parse date', value, error);
+    return null;
+  }
+};
+
+const getItemName = (item: PantryItem) => item.ingredient?.name ?? 'Este producto';
+
+const analyzeItemAlerts = (item: PantryItem): ItemAlertAnalysis => {
+  const tags: PantryAlertTag[] = [];
+  let expiryInfo: ExpiryInfo = null;
+
+  if (item.expiry_date) {
+    const parsedDate = safeParseDate(item.expiry_date);
+    if (parsedDate) {
+      const today = startOfDay(new Date());
+      const diff = differenceInCalendarDays(parsedDate, today);
+      if (diff < 0) {
+        tags.push('expired');
+        expiryInfo = { status: 'expired', diff };
+      } else if (diff <= NEAR_EXPIRY_THRESHOLD_DAYS) {
+        tags.push('near-expiry');
+        expiryInfo = { status: 'near-expiry', diff };
+      }
+    }
+  }
+
+  const minStock = item.min_stock ?? null;
+  if (minStock !== null) {
+    const quantity = typeof item.quantity === 'number' ? item.quantity : Number(item.quantity ?? 0);
+    if (Number.isFinite(quantity) && quantity <= minStock) {
+      tags.push('low-stock');
+    }
+  }
+
+  return { tags, expiryInfo };
+};
+
+const emitAlerts = (item: PantryItem, analysis: ItemAlertAnalysis, activeKeys: Set<string>) => {
+  const name = getItemName(item);
+  analysis.tags.forEach((tag) => {
+    const key = `${item.id}:${tag}`;
+    activeKeys.add(key);
+    if (alertHistory.has(key)) {
+      return;
+    }
+
+    if (tag === 'expired') {
+      const description = item.expiry_date ? `Caducó el ${item.expiry_date}.` : undefined;
+      toast.error(`${name} está vencido.`, { description });
+    } else if (tag === 'near-expiry') {
+      const days = analysis.expiryInfo ? analysis.expiryInfo.diff : 0;
+      const description =
+        days === 0 ? 'Caduca hoy.' : `Caduca en ${days} día${days === 1 ? '' : 's'}.`;
+      toast.warning(`${name} caducará pronto.`, { description });
+    } else if (tag === 'low-stock') {
+      const quantityText = typeof item.quantity === 'number' ? item.quantity : Number(item.quantity ?? 0);
+      const description = `Stock actual: ${Number.isFinite(quantityText) ? quantityText : '0'}${
+        item.unit ? ` ${item.unit}` : ''
+      }.`;
+      toast.warning(`${name} está por debajo del stock mínimo.`, { description });
+    }
+
+    alertHistory.add(key);
+  });
+};
+
+const calculateAlerts = (items: PantryItem[]) => {
+  const alertTags: Record<string, PantryAlertTag[]> = {};
+  const activeKeys = new Set<string>();
+  const activeFilters = new Set<PantryAlertTag>();
+
+  items.forEach((item) => {
+    const analysis = analyzeItemAlerts(item);
+    if (analysis.tags.length > 0) {
+      alertTags[item.id] = analysis.tags;
+      analysis.tags.forEach((tag) => activeFilters.add(tag));
+      emitAlerts(item, analysis, activeKeys);
+    }
+  });
+
+  Array.from(alertHistory).forEach((key) => {
+    if (!activeKeys.has(key)) {
+      alertHistory.delete(key);
+    }
+  });
+
+  const autoFilters = ALERT_PRIORITY.filter((tag) => activeFilters.has(tag));
+  return { alertTags, autoFilters };
+};
 
 export const usePantryStore = create<PantryState>((set, get) => ({
   items: [],
@@ -31,17 +144,23 @@ export const usePantryStore = create<PantryState>((set, get) => ({
   isLoadingLowStock: false,
   error: null,
   errorLowStock: null,
+  alertTags: {},
+  autoFilters: [],
+
+  clearAutoFilters: () => set({ autoFilters: [] }),
 
   fetchItems: async () => {
     if (get().isLoading) return;
     set({ isLoading: true, error: null });
     try {
       const items = await getItemsService();
-      set({ items, isLoading: false });
+      const { alertTags, autoFilters } = calculateAlerts(items);
+      set({ items, isLoading: false, alertTags, autoFilters });
     } catch (error) {
-      console.error("Error fetching pantry items for store:", error);
-      const errorMessage = error instanceof Error ? error.message : 'Error desconocido al cargar despensa.';
-      set({ error: errorMessage, isLoading: false });
+      console.error('Error fetching pantry items for store:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Error desconocido al cargar despensa.';
+      set({ error: errorMessage, isLoading: false, alertTags: {}, autoFilters: [] });
     }
   },
 
@@ -52,8 +171,9 @@ export const usePantryStore = create<PantryState>((set, get) => ({
       const lowStockItems = await fetchLowStockItemsService(threshold);
       set({ lowStockItems, isLoadingLowStock: false });
     } catch (error) {
-      console.error("Error fetching low stock items:", error);
-      const errorMessage = error instanceof Error ? error.message : 'Error desconocido al cargar items bajos de stock.';
+      console.error('Error fetching low stock items:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Error desconocido al cargar items bajos de stock.';
       set({ errorLowStock: errorMessage, isLoadingLowStock: false });
     }
   },
@@ -61,61 +181,70 @@ export const usePantryStore = create<PantryState>((set, get) => ({
   addItem: async (itemData: CreatePantryItemData) => {
     try {
       const newItem = await addItemService(itemData);
-      if (!newItem) throw new Error("Failed to add item");
-      set((state) => ({
-        items: [newItem, ...state.items].sort((a, b) =>
-          new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime()
-        )
-      }));
+      if (!newItem) throw new Error('Failed to add item');
+      set((state) => {
+        const items = [newItem, ...state.items].sort(
+          (a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
+        );
+        const { alertTags, autoFilters } = calculateAlerts(items);
+        return { items, alertTags, autoFilters };
+      });
       return newItem;
     } catch (error) {
-      console.error("Error adding pantry item via store:", error);
+      console.error('Error adding pantry item via store:', error);
       return null;
     }
   },
 
   updateItem: async (itemId: string, updates: UpdatePantryItemData) => {
     const originalItems = get().items;
-    const itemIndex = originalItems.findIndex(i => i.id === itemId);
+    const itemIndex = originalItems.findIndex((i) => i.id === itemId);
     if (itemIndex === -1) return null;
 
-    const updatedOptimisticItem = { ...originalItems[itemIndex], ...updates };
-    set((state) => ({
-      items: state.items.map(i => i.id === itemId ? updatedOptimisticItem : i)
-    }));
+    set((state) => {
+      const items = state.items.map((i) => (i.id === itemId ? { ...i, ...updates } : i));
+      const { alertTags, autoFilters } = calculateAlerts(items);
+      return { items, alertTags, autoFilters };
+    });
 
     try {
       const updatedItem = await updateItemService(itemId, updates);
-      if (!updatedItem) throw new Error("Update failed on server");
-      set((state) => ({
-        items: state.items.map(i => i.id === itemId ? updatedItem : i)
-      }));
+      if (!updatedItem) throw new Error('Update failed on server');
+      set((state) => {
+        const items = state.items.map((i) => (i.id === itemId ? updatedItem : i));
+        const { alertTags, autoFilters } = calculateAlerts(items);
+        return { items, alertTags, autoFilters };
+      });
       return updatedItem;
     } catch (error) {
-      console.error("Error updating pantry item via store:", error);
-      set({ items: originalItems });
+      console.error('Error updating pantry item via store:', error);
+      const { alertTags, autoFilters } = calculateAlerts(originalItems);
+      set({ items: originalItems, alertTags, autoFilters });
       return null;
     }
   },
 
   deleteItem: async (itemId: string) => {
     const originalItems = get().items;
-    set((state) => ({
-      items: state.items.filter(i => i.id !== itemId)
-    }));
+    set((state) => {
+      const items = state.items.filter((i) => i.id !== itemId);
+      const { alertTags, autoFilters } = calculateAlerts(items);
+      return { items, alertTags, autoFilters };
+    });
     try {
       await deleteItemService(itemId);
       return true;
     } catch (error) {
-      console.error("Error deleting pantry item via store:", error);
-      set({ items: originalItems });
+      console.error('Error deleting pantry item via store:', error);
+      const { alertTags, autoFilters } = calculateAlerts(originalItems);
+      set({ items: originalItems, alertTags, autoFilters });
       return false;
     }
   },
 
   toggleFavorite: async (itemId: string) => {
     const originalItems = get().items;
-    const itemIndex = originalItems.findIndex(i => i.id === itemId);
+    const itemIndex = originalItems.findIndex((i) => i.id === itemId);
     if (itemIndex === -1) {
       console.error(`[toggleFavorite] Item with ID ${itemId} not found in store.`);
       return;
@@ -125,19 +254,29 @@ export const usePantryStore = create<PantryState>((set, get) => ({
     const currentState = Boolean(currentItem.is_favorite);
     const newState = !currentState;
 
-    set((state) => ({
-      items: state.items.map(i => i.id === itemId ? { ...i, is_favorite: newState } : i)
-    }));
+    set((state) => {
+      const items = state.items.map((i) =>
+        i.id === itemId ? { ...i, is_favorite: newState } : i,
+      );
+      const { alertTags, autoFilters } = calculateAlerts(items);
+      return { items, alertTags, autoFilters };
+    });
 
     try {
       const updatedItem = await toggleFavoritePantryItem(itemId, newState);
       if (!updatedItem) {
-        throw new Error("Toggle favorite failed on server or item not found.");
+        throw new Error('Toggle favorite failed on server or item not found.');
       }
       console.log(`[toggleFavorite] Successfully toggled favorite for ${itemId} to ${newState}`);
+      set((state) => {
+        const items = state.items.map((i) => (i.id === itemId ? updatedItem : i));
+        const { alertTags, autoFilters } = calculateAlerts(items);
+        return { items, alertTags, autoFilters };
+      });
     } catch (error) {
-      console.error("Error toggling favorite via store:", error);
-      set({ items: originalItems });
+      console.error('Error toggling favorite via store:', error);
+      const { alertTags, autoFilters } = calculateAlerts(originalItems);
+      set({ items: originalItems, alertTags, autoFilters });
     }
   },
 }));

--- a/supabase/migrations/068_seed_base_categories.sql
+++ b/supabase/migrations/068_seed_base_categories.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+INSERT INTO public.categories (id, name, icon_name, color, "order", is_default, updated_at)
+VALUES
+  ('produce', 'Frutas y Verduras', 'carrot', '#4ade80', 1, true, timezone('utc', now())),
+  ('dairy', 'Lácteos y Huevos', 'milk', '#93c5fd', 2, true, timezone('utc', now())),
+  ('meat_fish', 'Carnes y Pescados', 'beef', '#fca5a5', 3, true, timezone('utc', now())),
+  ('pantry', 'Despensa Seca', 'package', '#fcd34d', 4, true, timezone('utc', now())),
+  ('frozen', 'Congelados', 'snowflake', '#bae6fd', 5, true, timezone('utc', now())),
+  ('beverages', 'Bebidas', 'glass-water', '#f9a8d4', 6, true, timezone('utc', now())),
+  ('cleaning', 'Limpieza y Hogar', 'spray', '#c4b5fd', 7, true, timezone('utc', now())),
+  ('personal_care', 'Cuidado Personal', 'bath', '#f0abfc', 8, true, timezone('utc', now())),
+  ('others', 'Otros', 'ellipsis', '#d4d4d8', 99, true, timezone('utc', now()))
+ON CONFLICT (id) DO UPDATE
+SET
+  name = EXCLUDED.name,
+  icon_name = EXCLUDED.icon_name,
+  color = EXCLUDED.color,
+  "order" = EXCLUDED."order",
+  is_default = true,
+  updated_at = timezone('utc', now());
+
+COMMIT;

--- a/supabase/migrations/069_create_measurement_units.sql
+++ b/supabase/migrations/069_create_measurement_units.sql
@@ -1,0 +1,38 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.measurement_units (
+  code TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  symbol TEXT,
+  unit_type TEXT NOT NULL DEFAULT 'general',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+COMMENT ON TABLE public.measurement_units IS 'Catálogo de unidades estandarizadas para recetas y despensa.';
+COMMENT ON COLUMN public.measurement_units.code IS 'Identificador corto y estable (por ejemplo, kg, ml, unidad).';
+COMMENT ON COLUMN public.measurement_units.unit_type IS 'Clasificación general de la unidad (masa, volumen, unidad, etc.).';
+
+INSERT INTO public.measurement_units (code, name, symbol, unit_type, updated_at)
+VALUES
+  ('g', 'Gramos', 'g', 'mass', timezone('utc', now())),
+  ('kg', 'Kilogramos', 'kg', 'mass', timezone('utc', now())),
+  ('mg', 'Miligramo', 'mg', 'mass', timezone('utc', now())),
+  ('lb', 'Libras', 'lb', 'mass', timezone('utc', now())),
+  ('oz', 'Onzas', 'oz', 'mass', timezone('utc', now())),
+  ('ml', 'Mililitros', 'ml', 'volume', timezone('utc', now())),
+  ('l', 'Litros', 'L', 'volume', timezone('utc', now())),
+  ('cup', 'Tazas', 'cup', 'volume', timezone('utc', now())),
+  ('tbsp', 'Cucharadas', 'tbsp', 'volume', timezone('utc', now())),
+  ('tsp', 'Cucharaditas', 'tsp', 'volume', timezone('utc', now())),
+  ('unit', 'Unidades', 'u', 'count', timezone('utc', now())),
+  ('pack', 'Paquetes', 'pkg', 'count', timezone('utc', now())),
+  ('slice', 'Rebanadas', 'slice', 'count', timezone('utc', now())),
+  ('bunch', 'Manojos', 'bunch', 'count', timezone('utc', now()))
+ON CONFLICT (code) DO UPDATE SET
+  name = EXCLUDED.name,
+  symbol = EXCLUDED.symbol,
+  unit_type = EXCLUDED.unit_type,
+  updated_at = timezone('utc', now());
+
+COMMIT;


### PR DESCRIPTION
## Summary
- implement PantryItemModal that reuses UnifiedPantryInput for quick parsing in create/edit flows
- enhance the shared pantry store with expiry/low-stock alerts, toasts, and auto-filter support
- switch pantry service calls to transactional upserts, expand coverage tests, and seed base categories/measurement units

## Testing
- npm test -- --runInBand src/features/pantry/pantryService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f29923edb083209818488674c86f7f