### PR TITLE
Add Supabase repository and seed data for core tables

### DIFF
--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -1,0 +1,92 @@
+# Configuración local de Supabase
+
+Esta guía describe cómo levantar Supabase en Docker utilizando la CLI oficial y cómo sincronizar las variables necesarias en `.env.local` para que la aplicación web utilice la instancia local.
+
+## Requisitos previos
+
+- [Supabase CLI](https://supabase.com/docs/guides/cli) instalada (v1.152 o superior).
+  - macOS/Linux: `brew install supabase/tap/supabase`
+  - Windows: `scoop install supabase`
+- Docker Desktop o motor Docker en ejecución.
+- Node.js instalado para ejecutar la aplicación (ver `README.md`).
+
+## 1. Inicializar el proyecto
+
+La carpeta `supabase/` contiene la configuración del proyecto (`config.toml`), migraciones y seeds. Para preparar el entorno local:
+
+```bash
+# Inicia los contenedores de Supabase (PostgreSQL, Kong, Studio, etc.)
+supabase start
+```
+
+Al finalizar, la CLI mostrará las URL y claves generadas para la instancia. Mantén la terminal abierta o copia estos valores.
+
+## 2. Aplicar migraciones y seeds
+
+Con los contenedores activos puedes aplicar todas las migraciones y el seed inicial:
+
+```bash
+# Limpia la base de datos, ejecuta migraciones y carga `supabase/seed.sql`
+supabase db reset --use-migra --seed supabase/seed.sql
+```
+
+Este comando reconstruye el esquema utilizando los archivos de `supabase/migrations` y pobla datos de referencia (categorías, unidades y recetas de ejemplo).
+
+Si solo quieres aplicar migraciones sin borrar datos existentes, usa:
+
+```bash
+supabase db push --seed supabase/seed.sql
+```
+
+## 3. Sincronizar `.env.local`
+
+La aplicación (Vite/React) lee las credenciales de Supabase desde `.env.local`. Después de ejecutar `supabase start` puedes obtener los valores vigentes con:
+
+```bash
+supabase status --json | jq '.services.db' # opcional para ver detalles
+supabase status
+```
+
+Crea o edita `.env.local` en la raíz del proyecto con las variables mínimas:
+
+```ini
+VITE_SUPABASE_URL=<API URL>
+VITE_SUPABASE_ANON_KEY=<anon key>
+SUPABASE_SERVICE_ROLE_KEY=<service_role key>
+```
+
+- `API URL` y `anon key` aparecen en la salida de `supabase start`/`status`.
+- `service_role key` es útil para scripts backend o ejecución de seeds personalizados.
+
+Cada vez que reinicies `supabase start`, verifica si cambiaron estas claves y actualiza `.env.local` para mantener la aplicación conectada.
+
+## 4. Ejecutar la aplicación
+
+Con Supabase y las variables configuradas:
+
+```bash
+npm install
+npm run dev
+```
+
+La app usará automáticamente la instancia local gracias a los valores definidos en `.env.local`.
+
+## 5. Apagar los contenedores
+
+Cuando termines, detén los servicios para liberar recursos:
+
+```bash
+supabase stop
+```
+
+Si quieres eliminar los contenedores e imágenes creados por la CLI, ejecuta:
+
+```bash
+supabase stop --destroy
+```
+
+## Notas adicionales
+
+- Los seeds utilizan el primer usuario existente en `auth.users` para asignar las recetas de ejemplo. Crea un usuario desde Supabase Studio o con `supabase auth signups create` antes de correr los seeds si la tabla está vacía.
+- El archivo `supabase/seed.sql` es idempotente: puedes re-ejecutarlo sin duplicar datos gracias a `ON CONFLICT` y comprobaciones internas.
+- Si modificas las migraciones, recuerda ejecutar `supabase db reset` para reconstruir el entorno local y validar los cambios.

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -109,6 +109,7 @@ export type Database = {
           created_at: string | null
           custom_meal_name: string | null
           id: string
+          meal_plan_id: string | null
           meal_type: string
           notes: string | null
           plan_date: string
@@ -121,6 +122,7 @@ export type Database = {
           created_at?: string | null
           custom_meal_name?: string | null
           id?: string
+          meal_plan_id?: string | null
           meal_type: string
           notes?: string | null
           plan_date: string
@@ -133,6 +135,7 @@ export type Database = {
           created_at?: string | null
           custom_meal_name?: string | null
           id?: string
+          meal_plan_id?: string | null
           meal_type?: string
           notes?: string | null
           plan_date?: string
@@ -147,6 +150,13 @@ export type Database = {
             columns: ["recipe_id"]
             isOneToOne: false
             referencedRelation: "recipes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "meal_plan_entries_meal_plan_id_fkey"
+            columns: ["meal_plan_id"]
+            isOneToOne: false
+            referencedRelation: "meal_plans"
             referencedColumns: ["id"]
           },
         ]
@@ -178,6 +188,36 @@ export type Database = {
           start_date?: string
           updated_at?: string
           user_id?: string
+        }
+        Relationships: []
+      }
+      measurement_units: {
+        Row: {
+          abbreviation: string
+          created_at: string
+          description: string | null
+          id: string
+          name: string
+          unit_group: string
+          updated_at: string
+        }
+        Insert: {
+          abbreviation: string
+          created_at?: string
+          description?: string | null
+          id: string
+          name: string
+          unit_group: string
+          updated_at?: string
+        }
+        Update: {
+          abbreviation?: string
+          created_at?: string
+          description?: string | null
+          id?: string
+          name?: string
+          unit_group?: string
+          updated_at?: string
         }
         Relationships: []
       }
@@ -708,13 +748,15 @@ export type Database = {
       shopping_list_items: {
         Row: {
           brand: string | null
-          category: string | null
+          category_id: string | null
           created_at: string
           id: string
+          ingredient_id: string | null
           ingredient_name: string
           is_checked: boolean
           notes: string | null
           quantity: number | null
+          recipe_id: string | null
           recipe_source: string | null
           unit: string | null
           updated_at: string
@@ -722,13 +764,15 @@ export type Database = {
         }
         Insert: {
           brand?: string | null
-          category?: string | null
+          category_id?: string | null
           created_at?: string
           id?: string
+          ingredient_id?: string | null
           ingredient_name: string
           is_checked?: boolean
           notes?: string | null
           quantity?: number | null
+          recipe_id?: string | null
           recipe_source?: string | null
           unit?: string | null
           updated_at?: string
@@ -736,19 +780,43 @@ export type Database = {
         }
         Update: {
           brand?: string | null
-          category?: string | null
+          category_id?: string | null
           created_at?: string
           id?: string
+          ingredient_id?: string | null
           ingredient_name?: string
           is_checked?: boolean
           notes?: string | null
           quantity?: number | null
+          recipe_id?: string | null
           recipe_source?: string | null
           unit?: string | null
           updated_at?: string
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "shopping_list_items_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shopping_list_items_ingredient_id_fkey"
+            columns: ["ingredient_id"]
+            isOneToOne: false
+            referencedRelation: "ingredients"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shopping_list_items_recipe_id_fkey"
+            columns: ["recipe_id"]
+            isOneToOne: false
+            referencedRelation: "recipes"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       shopping_suggestions: {
         Row: {
@@ -782,6 +850,50 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
+      }
+      user_preferences: {
+        Row: {
+          cooking_time_limit: number | null
+          created_at: string
+          dietary_preferences: string[]
+          disliked_ingredients: string[]
+          id: string
+          metadata: Json
+          preferred_cuisines: string[]
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          cooking_time_limit?: number | null
+          created_at?: string
+          dietary_preferences?: string[]
+          disliked_ingredients?: string[]
+          id?: string
+          metadata?: Json
+          preferred_cuisines?: string[]
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          cooking_time_limit?: number | null
+          created_at?: string
+          dietary_preferences?: string[]
+          disliked_ingredients?: string[]
+          id?: string
+          metadata?: Json
+          preferred_cuisines?: string[]
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_preferences_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       user_category_corrections: {
         Row: {

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -1,26 +1,27 @@
-import { supabase } from '@/lib/supabaseClient';
-import { Category } from '@/types/categoryTypes';
+import type { Category } from '@/types/categoryTypes';
+
+import { supabaseRepository } from './supabaseRepository';
 
 /**
  * Servicio central para funcionalidades compartidas
  * Actúa como punto único de acceso para operaciones comunes
  */
 
-/** 
+const categoriesTable = () => supabaseRepository.getClient().from('categories');
+
+/**
  * Obtiene todas las categorías disponibles
  */
 export async function getCategories(): Promise<Category[]> {
   try {
     console.log('[DataService] Fetching categories...');
-    const { data, error } = await supabase
-      .from('categories')
-      .select('*')
-      .order('name');
-
-    if (error) throw error;
+    const data = await supabaseRepository.run<Category[]>(
+      () => categoriesTable().select('*').order('name'),
+      { fallback: [] }
+    );
 
     console.log('[DataService] Categories fetched:', data);
-    return data || [];
+    return data;
   } catch (error) {
     console.error('[DataService] Error fetching categories:', error);
     throw error;
@@ -32,13 +33,11 @@ export async function getCategories(): Promise<Category[]> {
  */
 export async function getCategoryById(id: string): Promise<Category | null> {
   try {
-    const { data, error } = await supabase
-      .from('categories')
-      .select('*')
-      .eq('id', id)
-      .single();
+    const data = await supabaseRepository.run<Category | null>(
+      () => categoriesTable().select('*').eq('id', id).maybeSingle(),
+      { fallback: null }
+    );
 
-    if (error) throw error;
     return data;
   } catch (error) {
     console.error('[DataService] Error fetching category by id:', error);

--- a/src/services/supabaseRepository.ts
+++ b/src/services/supabaseRepository.ts
@@ -1,0 +1,145 @@
+import type {
+  AuthError,
+  PostgrestError,
+  PostgrestMaybeSingleResponse,
+  PostgrestResponse,
+  PostgrestSingleResponse,
+  SupabaseClient,
+  User,
+} from '@supabase/supabase-js';
+
+import { supabase } from '@/lib/supabaseClient';
+import type { Database } from '@/lib/database.types';
+
+export type PostgrestResult<T> =
+  | PostgrestResponse<T>
+  | PostgrestSingleResponse<T>
+  | PostgrestMaybeSingleResponse<T>;
+
+interface RunOptions<T> {
+  fallback?: T;
+}
+
+const AUTH_ERROR_CODES = new Set(['401', '403', 'PGRST301', '42501']);
+
+export class SupabaseRepository {
+  private readonly client: SupabaseClient<Database>;
+
+  constructor(client: SupabaseClient<Database>) {
+    this.client = client;
+  }
+
+  getClient(): SupabaseClient<Database> {
+    return this.client;
+  }
+
+  async run<T>(operation: () => Promise<PostgrestResult<T>>, options?: RunOptions<T>): Promise<T> {
+    const execute = async (): Promise<T> => {
+      const response = await operation();
+
+      if ('error' in response && response.error) {
+        throw response.error;
+      }
+
+      if ('data' in response) {
+        const data = response.data;
+
+        if (typeof data === 'undefined') {
+          throw new Error('Supabase query returned an undefined payload.');
+        }
+
+        if (data === null) {
+          if (options && 'fallback' in options) {
+            return options.fallback as T;
+          }
+
+          return data as T;
+        }
+
+        return data;
+      }
+
+      throw new Error('Unsupported Supabase response.');
+    };
+
+    try {
+      return await execute();
+    } catch (error) {
+      if (await this.tryRefreshSession(error)) {
+        return execute();
+      }
+
+      throw this.normalizeError(error);
+    }
+  }
+
+  async getCurrentUser(): Promise<User | null> {
+    const fetchUser = async () => {
+      const { data, error } = await this.client.auth.getUser();
+      if (error) throw error;
+      return data?.user ?? null;
+    };
+
+    try {
+      return await fetchUser();
+    } catch (error) {
+      if (await this.tryRefreshSession(error)) {
+        return fetchUser();
+      }
+
+      throw this.normalizeError(error);
+    }
+  }
+
+  private async tryRefreshSession(error: unknown): Promise<boolean> {
+    if (!this.shouldRefresh(error)) {
+      return false;
+    }
+
+    const { error: refreshError } = await this.client.auth.refreshSession();
+
+    if (refreshError) {
+      console.warn('[SupabaseRepository] Token refresh failed:', refreshError);
+      return false;
+    }
+
+    return true;
+  }
+
+  private shouldRefresh(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const maybePostgrest = error as Partial<PostgrestError>;
+    if (maybePostgrest.code && AUTH_ERROR_CODES.has(maybePostgrest.code)) {
+      return true;
+    }
+
+    if (typeof maybePostgrest.status === 'number' && AUTH_ERROR_CODES.has(String(maybePostgrest.status))) {
+      return true;
+    }
+
+    const maybeAuthError = error as Partial<AuthError>;
+    if (typeof maybeAuthError.status === 'number' && AUTH_ERROR_CODES.has(String(maybeAuthError.status))) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private normalizeError(error: unknown): Error {
+    if (error instanceof Error) {
+      return error;
+    }
+
+    if (error && typeof error === 'object' && 'message' in error) {
+      const message = String((error as { message: unknown }).message);
+      return new Error(message, { cause: error });
+    }
+
+    return new Error('Unexpected Supabase error.', { cause: error });
+  }
+}
+
+export const supabaseRepository = new SupabaseRepository(supabase as SupabaseClient<Database>);

--- a/supabase/migrations/068_add_missing_core_tables.sql
+++ b/supabase/migrations/068_add_missing_core_tables.sql
@@ -1,0 +1,252 @@
+-- Ensure meal_plans, shopping_list_items and user_preferences core tables exist
+-- with required relationships and indexes for the planning and shopping modules.
+
+-- 1. meal_plans table -------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'meal_plans'
+  ) THEN
+    CREATE TABLE public.meal_plans (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+      name text NOT NULL DEFAULT 'Plan semanal',
+      start_date date NOT NULL,
+      end_date date NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+      updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now())
+    );
+
+    COMMENT ON TABLE public.meal_plans IS 'Weekly meal plan metadata owned by each user.';
+    COMMENT ON COLUMN public.meal_plans.user_id IS 'Owner of the meal plan (maps to auth.users/id).';
+    COMMENT ON COLUMN public.meal_plans.start_date IS 'Inclusive start date for the plan.';
+    COMMENT ON COLUMN public.meal_plans.end_date IS 'Inclusive end date for the plan.';
+  END IF;
+END
+$$;
+
+ALTER TABLE public.meal_plans
+  ADD COLUMN IF NOT EXISTS name text;
+
+ALTER TABLE public.meal_plans
+  ALTER COLUMN name SET DEFAULT 'Plan semanal';
+
+ALTER TABLE public.meal_plans
+  ALTER COLUMN name SET NOT NULL;
+
+ALTER TABLE public.meal_plans
+  ADD COLUMN IF NOT EXISTS start_date date;
+
+ALTER TABLE public.meal_plans
+  ALTER COLUMN start_date SET NOT NULL;
+
+ALTER TABLE public.meal_plans
+  ADD COLUMN IF NOT EXISTS end_date date;
+
+ALTER TABLE public.meal_plans
+  ALTER COLUMN end_date SET NOT NULL;
+
+ALTER TABLE public.meal_plans
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now());
+
+ALTER TABLE public.meal_plans
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now());
+
+CREATE INDEX IF NOT EXISTS idx_meal_plans_user_dates
+  ON public.meal_plans (user_id, start_date, end_date);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'on_meal_plans_updated'
+      AND tgrelid = 'public.meal_plans'::regclass
+  ) THEN
+    CREATE TRIGGER on_meal_plans_updated
+      BEFORE UPDATE ON public.meal_plans
+      FOR EACH ROW
+      EXECUTE PROCEDURE public.handle_updated_at();
+  END IF;
+END
+$$;
+
+ALTER TABLE public.meal_plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.meal_plans FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'meal_plans'
+      AND policyname = 'Users manage their meal plans'
+  ) THEN
+    CREATE POLICY "Users manage their meal plans"
+      ON public.meal_plans
+      FOR ALL
+      USING (auth.uid() = user_id)
+      WITH CHECK (auth.uid() = user_id);
+  END IF;
+END
+$$;
+
+-- 2. Link meal_plan_entries with meal_plans when available ------------------
+ALTER TABLE public.meal_plan_entries
+  ADD COLUMN IF NOT EXISTS meal_plan_id uuid REFERENCES public.meal_plans(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_meal_plan_entries_plan
+  ON public.meal_plan_entries (meal_plan_id, plan_date);
+
+-- 3. shopping_list_items enhancements ---------------------------------------
+ALTER TABLE public.shopping_list_items
+  ADD COLUMN IF NOT EXISTS category_id text REFERENCES public.categories(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS ingredient_id uuid REFERENCES public.ingredients(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS recipe_id uuid REFERENCES public.recipes(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS notes text,
+  ADD COLUMN IF NOT EXISTS brand text;
+
+CREATE INDEX IF NOT EXISTS idx_shopping_list_items_user
+  ON public.shopping_list_items (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_shopping_list_items_user_checked
+  ON public.shopping_list_items (user_id, is_checked);
+
+CREATE INDEX IF NOT EXISTS idx_shopping_list_items_user_category
+  ON public.shopping_list_items (user_id, category_id);
+
+
+-- 3b. measurement_units reference table (shared catalogue) -------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'measurement_units'
+  ) THEN
+    CREATE TABLE public.measurement_units (
+      id text PRIMARY KEY,
+      name text NOT NULL,
+      abbreviation text NOT NULL,
+      unit_group text NOT NULL,
+      description text,
+      created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+      updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now())
+    );
+
+    COMMENT ON TABLE public.measurement_units IS 'Canonical list of measurement units for recipes and shopping lists.';
+    COMMENT ON COLUMN public.measurement_units.unit_group IS 'Category such as volume, weight or quantity.';
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_measurement_units_group
+  ON public.measurement_units (unit_group, abbreviation);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'on_measurement_units_updated'
+      AND tgrelid = 'public.measurement_units'::regclass
+  ) THEN
+    CREATE TRIGGER on_measurement_units_updated
+      BEFORE UPDATE ON public.measurement_units
+      FOR EACH ROW
+      EXECUTE PROCEDURE public.handle_updated_at();
+  END IF;
+END
+$$;
+-- 4. user_preferences table --------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'user_preferences'
+  ) THEN
+    CREATE TABLE public.user_preferences (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id uuid NOT NULL UNIQUE REFERENCES public.profiles(id) ON DELETE CASCADE,
+      dietary_preferences text[] NOT NULL DEFAULT ARRAY[]::text[],
+      disliked_ingredients text[] NOT NULL DEFAULT ARRAY[]::text[],
+      preferred_cuisines text[] NOT NULL DEFAULT ARRAY[]::text[],
+      cooking_time_limit integer,
+      created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+      updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+      metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+    );
+
+    COMMENT ON TABLE public.user_preferences IS 'Stores advanced preference settings that extend the profile.';
+    COMMENT ON COLUMN public.user_preferences.metadata IS 'Additional JSON settings such as allergies or equipment.';
+  END IF;
+END
+$$;
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS dietary_preferences text[] NOT NULL DEFAULT ARRAY[]::text[];
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS disliked_ingredients text[] NOT NULL DEFAULT ARRAY[]::text[];
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS preferred_cuisines text[] NOT NULL DEFAULT ARRAY[]::text[];
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS cooking_time_limit integer;
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now());
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now());
+
+CREATE INDEX IF NOT EXISTS idx_user_preferences_user
+  ON public.user_preferences (user_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'on_user_preferences_updated'
+      AND tgrelid = 'public.user_preferences'::regclass
+  ) THEN
+    CREATE TRIGGER on_user_preferences_updated
+      BEFORE UPDATE ON public.user_preferences
+      FOR EACH ROW
+      EXECUTE PROCEDURE public.handle_updated_at();
+  END IF;
+END
+$$;
+
+ALTER TABLE public.user_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_preferences FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_preferences'
+      AND policyname = 'Users manage their preferences'
+  ) THEN
+    CREATE POLICY "Users manage their preferences"
+      ON public.user_preferences
+      FOR ALL
+      USING (auth.uid() = user_id)
+      WITH CHECK (auth.uid() = user_id);
+  END IF;
+END
+$$;
+
+-- Final message -------------------------------------------------------------
+SELECT 'Core meal planning and shopping tables verified.';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,157 @@
+-- Seed data for local Supabase development
+-- 1. Default categories ------------------------------------------------------
+INSERT INTO public.categories (id, name, icon, color, "order", is_default)
+VALUES
+  ('produce', 'Frutas y Verduras', 'carrot', '#4ade80', 1, true),
+  ('protein', 'Proteínas', 'beef', '#fca5a5', 2, true),
+  ('grains', 'Granos y Cereales', 'bread', '#facc15', 3, true),
+  ('dairy_and_eggs', 'Lácteos y Huevos', 'milk', '#bfdbfe', 4, true)
+ON CONFLICT (id) DO UPDATE
+SET
+  name = EXCLUDED.name,
+  icon = EXCLUDED.icon,
+  color = EXCLUDED.color,
+  "order" = EXCLUDED."order",
+  is_default = EXCLUDED.is_default;
+
+-- 2. Measurement units catalogue --------------------------------------------
+INSERT INTO public.measurement_units (id, name, abbreviation, unit_group, description)
+VALUES
+  ('gram', 'Gramo', 'g', 'weight', 'Unidad básica de peso para ingredientes sólidos.'),
+  ('kilogram', 'Kilogramo', 'kg', 'weight', 'Equivale a 1000 gramos.'),
+  ('milliliter', 'Mililitro', 'ml', 'volume', 'Unidad para mediciones pequeñas de volumen.'),
+  ('liter', 'Litro', 'l', 'volume', 'Equivale a 1000 mililitros.'),
+  ('unit', 'Unidad', 'ud', 'quantity', 'Cuenta piezas individuales.'),
+  ('cup', 'Taza', 'cup', 'volume', 'Medida estándar de cocina (aprox. 240 ml).')
+ON CONFLICT (id) DO UPDATE
+SET
+  name = EXCLUDED.name,
+  abbreviation = EXCLUDED.abbreviation,
+  unit_group = EXCLUDED.unit_group,
+  description = EXCLUDED.description;
+
+-- 3. Sample recipes (requires at least one user in auth.users) ---------------
+WITH existing_user AS (
+  SELECT id
+  FROM auth.users
+  ORDER BY created_at
+  LIMIT 1
+),
+inserted_recipe AS (
+  INSERT INTO public.recipes (
+    id,
+    user_id,
+    title,
+    description,
+    instructions,
+    servings,
+    prep_time_minutes,
+    cook_time_minutes,
+    is_public,
+    is_generated_base,
+    is_favorite
+  )
+  SELECT
+    gen_random_uuid() AS id,
+    existing_user.id AS user_id,
+    'Ensalada Mediterránea' AS title,
+    'Ensalada fresca con vegetales, queso feta y aderezo de limón.' AS description,
+    '1. Cortar vegetales. 2. Mezclar con queso. 3. Aliñar y servir.' AS instructions,
+    2 AS servings,
+    15 AS prep_time_minutes,
+    0 AS cook_time_minutes,
+    true AS is_public,
+    false AS is_generated_base,
+    false AS is_favorite
+  FROM existing_user
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.recipes
+    WHERE title = 'Ensalada Mediterránea'
+  )
+  RETURNING id, user_id
+),
+inserted_ingredients AS (
+  INSERT INTO public.recipe_ingredients (recipe_id, ingredient_name, quantity, unit)
+  SELECT inserted_recipe.id, ingredient_name, quantity, unit
+  FROM inserted_recipe
+  JOIN (
+    VALUES
+      ('Tomate cherry', 200::numeric, 'g'),
+      ('Pepino', 1::numeric, 'unit'),
+      ('Queso feta', 100::numeric, 'g'),
+      ('Aceite de oliva', 30::numeric, 'ml'),
+      ('Jugo de limón', 15::numeric, 'ml')
+  ) AS seed_items(ingredient_name, quantity, unit) ON TRUE
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.recipe_ingredients ri
+    WHERE ri.recipe_id = inserted_recipe.id
+  )
+  RETURNING 1
+)
+SELECT 'Inserted mediterranean salad recipe' AS message
+WHERE EXISTS (SELECT 1 FROM inserted_recipe);
+
+-- Additional sample: pasta primavera ----------------------------------------
+WITH existing_user AS (
+  SELECT id
+  FROM auth.users
+  ORDER BY created_at
+  LIMIT 1
+),
+inserted_recipe AS (
+  INSERT INTO public.recipes (
+    id,
+    user_id,
+    title,
+    description,
+    instructions,
+    servings,
+    prep_time_minutes,
+    cook_time_minutes,
+    is_public,
+    is_generated_base,
+    is_favorite
+  )
+  SELECT
+    gen_random_uuid(),
+    existing_user.id,
+    'Pasta Primavera Rápida',
+    'Pasta con vegetales salteados y salsa ligera.',
+    '1. Cocinar la pasta. 2. Saltear vegetales. 3. Mezclar y servir.',
+    4,
+    10,
+    12,
+    true,
+    false,
+    false
+  FROM existing_user
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.recipes
+    WHERE title = 'Pasta Primavera Rápida'
+  )
+  RETURNING id, user_id
+),
+inserted_ingredients AS (
+  INSERT INTO public.recipe_ingredients (recipe_id, ingredient_name, quantity, unit)
+  SELECT inserted_recipe.id, ingredient_name, quantity, unit
+  FROM inserted_recipe
+  JOIN (
+    VALUES
+      ('Pasta corta', 320::numeric, 'g'),
+      ('Pimiento rojo', 1::numeric, 'unit'),
+      ('Calabacín', 1::numeric, 'unit'),
+      ('Aceite de oliva', 30::numeric, 'ml'),
+      ('Ajo', 2::numeric, 'unit')
+  ) AS seed_items(ingredient_name, quantity, unit) ON TRUE
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.recipe_ingredients ri
+    WHERE ri.recipe_id = inserted_recipe.id
+  )
+  RETURNING 1
+)
+SELECT 'Inserted pasta primavera recipe' AS message
+WHERE EXISTS (SELECT 1 FROM inserted_recipe);


### PR DESCRIPTION
## Summary
- add a migration that ensures core Supabase tables (meal plans, shopping list items, user preferences, measurement units) exist with the expected constraints
- seed default categories, measurement units and example recipes for local environments and document how to run Supabase with Docker
- introduce a shared Supabase repository service that centralizes error handling/token refresh and update the data service to consume it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2992ac3408320a0c3abd84d2be47f