### PR TITLE
feat: unify app layout and add design tokens

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,19 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/components/stories/**/*.mdx', '../src/components/stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    '@storybook/addon-a11y',
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  docs: {
+    autodocs: 'tag',
+  },
+};
+
+export default config;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,24 @@
+import type { Preview } from '@storybook/react';
+import '../src/index.css';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-background text-foreground">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default preview;

--- a/design-tokens.js
+++ b/design-tokens.js
@@ -1,0 +1,54 @@
+export const themeTokens = {
+  colors: {
+    border: 'hsl(var(--border))',
+    input: 'hsl(var(--input))',
+    ring: 'hsl(var(--ring))',
+    background: 'hsl(var(--background))',
+    foreground: 'hsl(var(--foreground))',
+    muted: {
+      DEFAULT: 'hsl(var(--muted))',
+      foreground: 'hsl(var(--muted-foreground))',
+    },
+    popover: {
+      DEFAULT: 'hsl(var(--popover))',
+      foreground: 'hsl(var(--popover-foreground))',
+    },
+    card: {
+      DEFAULT: 'hsl(var(--card))',
+      foreground: 'hsl(var(--card-foreground))',
+    },
+    primary: {
+      DEFAULT: 'hsl(var(--primary))',
+      foreground: 'hsl(var(--primary-foreground))',
+    },
+    secondary: {
+      DEFAULT: 'hsl(var(--secondary))',
+      foreground: 'hsl(var(--secondary-foreground))',
+    },
+    destructive: {
+      DEFAULT: 'hsl(var(--destructive))',
+      foreground: 'hsl(var(--destructive-foreground))',
+    },
+    accent: {
+      DEFAULT: 'hsl(var(--accent))',
+      foreground: 'hsl(var(--accent-foreground))',
+    },
+  },
+  spacing: {
+    'page-inline': 'var(--spacing-page-inline)',
+    'page-block': 'var(--spacing-page-block)',
+    section: 'var(--spacing-section)',
+    'section-sm': 'var(--spacing-section-sm)',
+    'section-lg': 'var(--spacing-section-lg)',
+  },
+  radii: {
+    base: 'var(--radius)',
+    lg: 'calc(var(--radius) + 4px)',
+  },
+  maxWidth: {
+    page: 'var(--max-width-page)',
+    content: 'var(--max-width-content)',
+  },
+};
+
+export default themeTokens;

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,75 @@
+# Sistema de diseño
+
+Esta guía documenta los patrones base del layout interno de la aplicación y los tokens de diseño que los sustentan. Utiliza esta referencia para mantener coherencia visual al crear o actualizar pantallas.
+
+## Tokens compartidos
+
+Los tokens están centralizados en [`design-tokens.js`](../design-tokens.js) y expuestos en TypeScript mediante [`src/config/theme.ts`](../src/config/theme.ts). Además, los tokens se inyectan en Tailwind a través de `tailwind.config.js`, por lo que puedes usarlos directamente como utilidades (`px-page-inline`, `gap-section`, etc.).
+
+### Espaciados
+
+| Token Tailwind            | Variable CSS                    | Uso recomendado                          |
+|---------------------------|---------------------------------|------------------------------------------|
+| `page-inline`             | `--spacing-page-inline`         | Sangría horizontal general del layout    |
+| `page-block`              | `--spacing-page-block`          | Separación vertical entre áreas de página|
+| `section-sm`              | `--spacing-section-sm`          | Gaps compactos dentro de tarjetas        |
+| `section`                 | `--spacing-section`             | Distancia estándar entre bloques         |
+| `section-lg`              | `--spacing-section-lg`          | Secciones destacadas o bloques amplios   |
+
+### Colores semánticos
+
+Todos los colores se exponen como `hsl(var(--token))` para soportar temas claro/oscuro. Usa las claves de `theme.colors` para extender utilidades cuando se necesite personalización específica.
+
+## Patrones de layout
+
+### `PageLayout`
+
+Componente principal para páginas internas. Envuelve el contenido con el padding estándar, alinea el header con icono y acciones, y limita el ancho máximo (`maxWidth` por defecto `page`).
+
+```tsx
+<PageLayout
+  title="Mi Despensa"
+  description="Gestiona tus ingredientes y favoritos."
+  icon={<ShoppingBasket className="h-6 w-6" />}
+  actions={<Button>Acción</Button>}
+>
+  {/* Secciones de contenido */}
+</PageLayout>
+```
+
+Usa `maxWidth="full"` cuando una pantalla deba ocupar todo el ancho (por ejemplo, layout con mapa o grids extensos).
+
+### `PageSection`
+
+Tarjeta elevada con border y fondo (`bg-card`) alineada al diseño. Integra automáticamente `PageHeader` cuando recibe `title`, `description` o `icon`, y expone `actions` para controles locales.
+
+```tsx
+<PageSection
+  title="Resumen semanal"
+  description="Estado de comidas planificadas."
+  actions={<Button variant="outline">Exportar</Button>}
+>
+  <DashboardCards />
+</PageSection>
+```
+
+Utiliza `padded={false}` + `contentClassName="p-0"` cuando un bloque hijo gestione su propio padding (por ejemplo, layouts responsivos o tablas con scroll).
+
+### `PageHeader`
+
+Componente de cabecera reutilizable que ahora admite iconos, descripción y clases personalizadas. Evita crear cabeceras manuales; usa este componente dentro de `PageLayout` o `PageSection` para mantener tipografía y espaciados consistentes.
+
+## Historias visuales
+
+Los componentes de layout disponen de historias en `src/components/stories` para validar regresiones visuales con Storybook/Chromatic:
+
+- `PageLayout.stories.tsx`
+- `PageSection.stories.tsx`
+
+Al añadir nuevos patrones, crea historias equivalentes para facilitar pruebas visuales automáticas.
+
+## Buenas prácticas
+
+1. **Componentes de página** (`PantryPage`, `RecipesPage`, `PlanningPage`, `ShoppingListPage`) deben renderizarse dentro de `PageLayout` y dividir su contenido mediante `PageSection`.
+2. **Tokens primero**: evita valores mágicos en clases Tailwind; recurre a los tokens extendidos (`gap-section`, `px-page-inline`, etc.).
+3. **Documentación sincronizada**: cuando introduzcas un nuevo patrón o token, actualiza este documento y exporta los cambios en `design-tokens.js` / `theme.ts`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -69,6 +71,11 @@
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.27.0",
+    "@storybook/addon-a11y": "^8.5.4",
+    "@storybook/addon-essentials": "^8.5.4",
+    "@storybook/addon-interactions": "^8.5.4",
+    "@storybook/react": "^8.5.4",
+    "@storybook/react-vite": "^8.5.4",
     "@jest/globals": "^29.7.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
@@ -90,6 +97,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.33",
     "rollup-plugin-visualizer": "^5.14.0",
+    "storybook": "^8.5.4",
     "supabase": "^2.20.12",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.1.2",

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from 'react';
+import { PageHeader, PageHeaderProps } from '@/components/ui/PageHeader';
+import { cn } from '@/lib/utils';
+
+const MAX_WIDTH_CLASSNAME: Record<'page' | 'content' | 'full', string> = {
+  page: 'max-w-page',
+  content: 'max-w-content',
+  full: 'max-w-none',
+};
+
+export interface PageLayoutProps extends PageHeaderProps {
+  actions?: ReactNode;
+  children: ReactNode;
+  maxWidth?: keyof typeof MAX_WIDTH_CLASSNAME;
+  className?: string;
+  contentClassName?: string;
+}
+
+export function PageLayout({
+  title,
+  description,
+  icon,
+  actions,
+  children,
+  maxWidth = 'page',
+  className,
+  contentClassName,
+}: PageLayoutProps) {
+  const hasHeaderContent = title || description || icon || actions;
+
+  return (
+    <div className={cn('w-full', className)}>
+      <div
+        className={cn(
+          'mx-auto flex w-full flex-col gap-section px-page-inline py-page-block',
+          MAX_WIDTH_CLASSNAME[maxWidth],
+          contentClassName,
+        )}
+      >
+        {hasHeaderContent && (
+          <div className="flex flex-col gap-section-sm sm:flex-row sm:items-center sm:justify-between">
+            <PageHeader title={title} description={description} icon={icon} />
+            {actions && <div className="flex flex-wrap items-center gap-section-sm">{actions}</div>}
+          </div>
+        )}
+        <div className="flex flex-col gap-section">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/stories/PageLayout.stories.tsx
+++ b/src/components/stories/PageLayout.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShoppingBasket, CalendarDays } from 'lucide-react';
+import { PageLayout } from '../layout/PageLayout';
+import { PageSection } from '../ui/PageSection';
+import { Button } from '../ui/button';
+
+const meta: Meta<typeof PageLayout> = {
+  title: 'Layout/PageLayout',
+  component: PageLayout,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PageLayout>;
+
+export const Default: Story = {
+  render: () => (
+    <PageLayout
+      title="Mi Despensa"
+      description="Gestiona tus ingredientes y favoritos desde un único lugar."
+      icon={<ShoppingBasket className="h-6 w-6" />}
+      actions={<Button size="sm">Añadir ítem</Button>}
+    >
+      <PageSection title="Resumen" description="Estado general de la semana">
+        <div className="grid gap-section sm:grid-cols-2">
+          <div className="rounded-xl border border-dashed border-muted/60 p-section text-sm text-muted-foreground">
+            Contenido de ejemplo A
+          </div>
+          <div className="rounded-xl border border-dashed border-muted/60 p-section text-sm text-muted-foreground">
+            Contenido de ejemplo B
+          </div>
+        </div>
+      </PageSection>
+      <PageSection
+        title="Actividades recientes"
+        description="Últimas acciones registradas en la lista"
+        actions={<Button variant="outline" size="sm">Ver historial</Button>}
+      >
+        <ul className="space-y-section-sm text-sm text-muted-foreground">
+          <li>Se añadió "Tomates" a la despensa hace 2 horas.</li>
+          <li>Se marcó "Pasta" como agotado hace 5 horas.</li>
+          <li>Se actualizó el plan semanal ayer.</li>
+        </ul>
+      </PageSection>
+    </PageLayout>
+  ),
+};
+
+export const FullWidth: Story = {
+  render: () => (
+    <PageLayout
+      title="Planificación semanal"
+      description="Visualiza las comidas del lunes al domingo."
+      icon={<CalendarDays className="h-6 w-6" />}
+      actions={
+        <div className="flex gap-section-sm">
+          <Button variant="outline" size="sm">Autocompletar</Button>
+          <Button size="sm">Generar lista</Button>
+        </div>
+      }
+      maxWidth="full"
+    >
+      <PageSection padded={false} className="overflow-hidden" contentClassName="p-0">
+        <div className="grid gap-section-sm md:grid-cols-7">
+          {[...Array(7)].map((_, index) => (
+            <div key={index} className="rounded-xl border border-dashed border-muted/60 p-section text-sm text-muted-foreground">
+              Día {index + 1}
+            </div>
+          ))}
+        </div>
+      </PageSection>
+    </PageLayout>
+  ),
+};

--- a/src/components/stories/PageSection.stories.tsx
+++ b/src/components/stories/PageSection.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Layers, Settings } from 'lucide-react';
+import { PageSection } from '../ui/PageSection';
+import { Button } from '../ui/button';
+
+const meta: Meta<typeof PageSection> = {
+  title: 'Layout/PageSection',
+  component: PageSection,
+  args: {
+    children: <div className="text-sm text-muted-foreground">Contenido de ejemplo</div>,
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PageSection>;
+
+export const Default: Story = {
+  args: {
+    title: 'Sección informativa',
+    description: 'Agrupa información relacionada dentro de un contenedor con borde.',
+    icon: <Layers className="h-5 w-5" />,
+    actions: <Button size="sm">Acción principal</Button>,
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    padded: false,
+    title: 'Encabezado compacto',
+    icon: <Settings className="h-5 w-5" />,
+    actions: (
+      <div className="flex gap-section-sm">
+        <Button variant="outline" size="sm">Cancelar</Button>
+        <Button size="sm">Guardar</Button>
+      </div>
+    ),
+    contentClassName: 'p-section',
+    children: (
+      <div className="rounded-lg border border-dashed border-muted/60 p-section-sm text-sm text-muted-foreground">
+        Este modo resulta útil cuando un componente hijo controla el espaciado interno.
+      </div>
+    ),
+  },
+};
+
+export const WithoutHeader: Story = {
+  args: {
+    children: (
+      <div className="space-y-section-sm text-sm text-muted-foreground">
+        <p>No se proporciona título, por lo que el contenedor actúa como bloque neutro.</p>
+        <p>Ideal para agrupar controles secundarios o tablas responsivas.</p>
+      </div>
+    ),
+  },
+};

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -1,25 +1,27 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
 
-interface PageHeaderProps {
-  title: string;
+export interface PageHeaderProps {
+  title?: string;
   description?: string;
   icon?: ReactNode;
+  className?: string;
 }
 
-export function PageHeader({ title, description, icon }: PageHeaderProps) {
+export function PageHeader({ title, description, icon, className }: PageHeaderProps) {
   return (
-    <div className="flex items-center space-x-4">
+    <div className={cn('flex items-start gap-section-sm', className)}>
       {icon && (
-        <div className="flex-shrink-0 p-1 bg-primary/10 rounded-lg">
-          <div className="text-primary">{icon}</div>
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          {icon}
         </div>
       )}
       <div>
-        <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+        {title && <h1 className="text-2xl font-semibold tracking-tight text-foreground">{title}</h1>}
         {description && (
-          <p className="text-sm text-muted-foreground">{description}</p>
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
         )}
       </div>
     </div>
   );
-} 
+}

--- a/src/components/ui/PageSection.tsx
+++ b/src/components/ui/PageSection.tsx
@@ -1,0 +1,61 @@
+import { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+import { PageHeader } from './PageHeader';
+
+type PageHeaderProps = React.ComponentProps<typeof PageHeader>;
+
+interface PageSectionProps extends Partial<PageHeaderProps> {
+  children: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  padded?: boolean;
+  headerClassName?: string;
+}
+
+export function PageSection({
+  title,
+  description,
+  icon,
+  actions,
+  children,
+  className,
+  contentClassName,
+  padded = true,
+  headerClassName,
+}: PageSectionProps) {
+  const hasHeaderContent = title || description || icon || actions;
+
+  return (
+    <section
+      className={cn(
+        'rounded-2xl border border-border bg-card shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/95',
+        className,
+      )}
+    >
+      {hasHeaderContent && (
+        <div
+          className={cn(
+            'flex flex-col gap-section-sm border-b border-border sm:flex-row sm:items-center sm:justify-between',
+            padded ? 'px-section py-section' : 'px-section py-section-sm',
+            headerClassName,
+          )}
+        >
+          <PageHeader title={title} description={description} icon={icon} />
+          {actions && <div className="flex flex-wrap items-center gap-section-sm">{actions}</div>}
+        </div>
+      )}
+
+      <div
+        className={cn(
+          'flex flex-col',
+          padded ? 'px-section py-section' : undefined,
+          padded ? 'gap-section' : 'gap-section-sm',
+          contentClassName,
+        )}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,0 +1,18 @@
+import tokens from '../../design-tokens.js';
+
+export const theme = {
+  colors: tokens.colors,
+  spacing: tokens.spacing,
+  radii: tokens.radii,
+  maxWidth: tokens.maxWidth,
+} as const;
+
+export type ThemeConfig = typeof theme;
+
+export type ColorToken = keyof ThemeConfig['colors'];
+export type SpacingToken = keyof ThemeConfig['spacing'];
+
+export const getColorToken = (token: ColorToken) => theme.colors[token];
+export const getSpacingToken = (token: SpacingToken) => theme.spacing[token];
+
+export const designTokens = theme;

--- a/src/features/pantry/PantryPage.tsx
+++ b/src/features/pantry/PantryPage.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { List, LayoutGrid } from 'lucide-react';
+import { List, LayoutGrid, ShoppingBasket } from 'lucide-react';
 import { toast } from 'sonner';
-import { EmptyState } from '@/components/common/EmptyState';
 import { Spinner } from '@/components/ui/Spinner';
 import {
   getPantryItems,
@@ -20,6 +18,8 @@ import PantryFiltersSection from './components/PantryFiltersSection';
 import PantrySelectionControls from './components/PantrySelectionControls';
 import PantryItemsView from './components/PantryItemsView';
 import UnifiedPantryInput from './components/UnifiedPantryInput';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageSection } from '@/components/ui/PageSection';
 
 export function PantryPage() {
   // Estados del componente
@@ -146,14 +146,30 @@ export function PantryPage() {
     }
   }, [pantryItems]); // Depender de pantryItems para tener el currentState correcto
 
+  const handleEnterSelectionMode = useCallback(() => {
+    setIsSelectionMode(true);
+  }, []);
+
+  const handleCancelSelection = useCallback(() => {
+    setIsSelectionMode(false);
+    setSelectedItems(new Set());
+  }, []);
+
+  const handleSelectAllItems = useCallback(() => {
+    setSelectedItems(new Set(pantryItems.map(item => item.id)));
+  }, [pantryItems]);
+
+  const handleDeselectAllItems = useCallback(() => {
+    setSelectedItems(new Set());
+  }, []);
+
   const handleDeleteSelected = async () => {
     try {
       const itemIdsArray = Array.from(selectedItems);
       await deleteMultiplePantryItems(itemIdsArray);
       toast.success(`${itemIdsArray.length} items eliminados`);
       await loadData();
-      setIsSelectionMode(false);
-      setSelectedItems(new Set());
+      handleCancelSelection();
     } catch (err) {
       console.error("Error deleting items:", err);
       toast.error("Error al eliminar los items seleccionados");
@@ -214,112 +230,88 @@ export function PantryPage() {
     });
   }, [pantryItems, categories, filters]);
 
-  return (
-    <div className="container mx-auto py-8 px-4 md:px-6 lg:px-8 relative">
-      <Card>
-        <CardHeader className="pb-4">
-          {/* Título y Controles de Selección/Vista */}
-          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 mb-4">
-            <CardTitle className="text-2xl font-bold">Mi Despensa</CardTitle>
-            <div className="flex items-center gap-2 flex-shrink-0 flex-wrap">
-              <Suspense fallback={null}>
-                {!isSelectionMode ? (
-                  <>
-                    {isDesktop && (
-                      <>
-                        <Button
-                          variant={viewMode === 'list' ? 'secondary' : 'ghost'}
-                          size="sm"
-                          onClick={() => setViewMode('list')}
-                        >
-                          <List className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant={viewMode === 'grid' ? 'secondary' : 'ghost'}
-                          size="sm"
-                          onClick={() => setViewMode('grid')}
-                        >
-                          <LayoutGrid className="h-4 w-4" />
-                        </Button>
-                      </>
-                    )}
-                    <PantrySelectionControls
-                      isSelectionMode={isSelectionMode}
-                      selectedItems={selectedItems}
-                      onSelectAll={() => setSelectedItems(new Set(pantryItems.map(item => item.id)))}
-                      onDeselectAll={() => setSelectedItems(new Set())}
-                      onEnterSelectionMode={() => setIsSelectionMode(true)}
-                      onCancelSelection={() => { /* No necesario si el botón solo aparece en modo selección */ }}
-                      onDeleteSelected={handleDeleteSelected}
-                      totalVisibleItems={pantryItems.length}
-                    />
-                  </>
-                ) : (
-                  <PantrySelectionControls
-                    isSelectionMode={isSelectionMode}
-                    selectedItems={selectedItems}
-                    onSelectAll={() => setSelectedItems(new Set(pantryItems.map(item => item.id)))}
-                    onDeselectAll={() => setSelectedItems(new Set())}
-                    onEnterSelectionMode={() => setIsSelectionMode(true)} // Redundante aquí?
-                    onCancelSelection={() => {
-                      setIsSelectionMode(false);
-                      setSelectedItems(new Set());
-                    }}
-                    onDeleteSelected={handleDeleteSelected}
-                    totalVisibleItems={pantryItems.length}
-                  />
-                )}
-              </Suspense>
-            </div>
-          </div>
+  const headerActions = (
+    <div className="flex flex-wrap items-center gap-section-sm">
+      {!isSelectionMode && isDesktop && (
+        <div className="inline-flex items-center gap-1 rounded-full border border-border bg-muted/50 p-1">
+          <Button
+            variant={viewMode === 'list' ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => setViewMode('list')}
+            aria-pressed={viewMode === 'list'}
+          >
+            <List className="h-4 w-4" />
+          </Button>
+          <Button
+            variant={viewMode === 'grid' ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => setViewMode('grid')}
+            aria-pressed={viewMode === 'grid'}
+          >
+            <LayoutGrid className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+      <PantrySelectionControls
+        isSelectionMode={isSelectionMode}
+        selectedItems={selectedItems}
+        onEnterSelectionMode={handleEnterSelectionMode}
+        onSelectAll={handleSelectAllItems}
+        onDeselectAll={handleDeselectAllItems}
+        onCancelSelection={handleCancelSelection}
+        onDeleteSelected={handleDeleteSelected}
+        totalVisibleItems={pantryItems.length}
+      />
+    </div>
+  );
 
-          {/* Filtros */}
-          <Suspense fallback={null}>
-            <PantryFiltersSection
-              categories={categories}
-              isDesktop={isDesktop}
-              filters={filters}
-              onFilterChange={handleFilterChange}
-              showFiltersSheet={showFiltersSheet} // ¿Se usa?
-              setShowFiltersSheet={setShowFiltersSheet} // ¿Se usa?
-              pantryItems={pantryItems}
-              onClearPantry={handleClearPantry}
+  return (
+    <PageLayout
+      title="Mi Despensa"
+      description="Gestiona tus ingredientes y favoritos desde un único panel."
+      icon={<ShoppingBasket className="h-6 w-6" />}
+      actions={headerActions}
+    >
+      <PageSection padded>
+        <Suspense fallback={null}>
+          <PantryFiltersSection
+            categories={categories}
+            isDesktop={isDesktop}
+            filters={filters}
+            onFilterChange={handleFilterChange}
+            showFiltersSheet={showFiltersSheet}
+            setShowFiltersSheet={setShowFiltersSheet}
+            pantryItems={pantryItems}
+            onClearPantry={handleClearPantry}
+          />
+        </Suspense>
+
+        {!isSelectionMode && (
+          <Suspense fallback={<Spinner size="sm" />}>
+            <UnifiedPantryInput
+              onItemAdded={loadData}
+              availableCategories={categories}
+              onEditRequest={handleEditRequestFromUnifiedInput}
             />
           </Suspense>
-        </CardHeader>
-
-        {/* Input Unificado (Movido aquí) */}
-        {!isSelectionMode && (
-          <div className="px-4 md:px-6 lg:px-8 pt-4 pb-2 border-t border-b"> {/* Padding y bordes */}
-            <Suspense fallback={<Spinner size="sm" />}>
-              <UnifiedPantryInput
-                onItemAdded={loadData}
-                availableCategories={categories}
-                onEditRequest={handleEditRequestFromUnifiedInput}
-              />
-            </Suspense>
-          </div>
         )}
 
-        {/* Contenido Principal (Lista/Grid) */}
-        <CardContent className="pt-6 pb-6"> {/* Padding ajustado */}
-          <Suspense fallback={<Spinner />}>
-            <PantryItemsView
-              viewMode={viewMode}
-              processedItems={processedItems}
-              isLoading={isLoading}
-              error={error}
-              isSelectionMode={isSelectionMode}
-              selectedItems={selectedItems}
-              onSelectItem={handleSelectItem}
-              onEditItem={handleEditItem} // Pasar handler de edición
-              onDeleteItem={() => {}} // TODO: Implementar delete individual si es necesario
-              onToggleFavorite={handleToggleFavorite}
-            />
-          </Suspense>
-        </CardContent>
-      </Card>
-    </div>
+        <Suspense fallback={<Spinner />}>
+          <PantryItemsView
+            viewMode={viewMode}
+            processedItems={processedItems}
+            isLoading={isLoading}
+            error={error}
+            isSelectionMode={isSelectionMode}
+            selectedItems={selectedItems}
+            onSelectItem={handleSelectItem}
+            onEditItem={handleEditItem}
+            onDeleteItem={() => {}}
+            onToggleFavorite={handleToggleFavorite}
+          />
+        </Suspense>
+      </PageSection>
+    </PageLayout>
   );
 }
 

--- a/src/features/planning/PlanningPage.tsx
+++ b/src/features/planning/PlanningPage.tsx
@@ -37,6 +37,9 @@ import { es } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
 import useBreakpoint from '@/hooks/useBreakpoint';
 import { toast } from 'sonner';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageSection } from '@/components/ui/PageSection';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 
 const getWeekInterval = (date: Date): { start: Date; end: Date } => {
   const start = startOfWeek(date, { weekStartsOn: 1 });
@@ -98,6 +101,10 @@ const PlanningPage: React.FC = () => {
   const weekEndStr = useMemo(() => format(weekEnd, 'yyyy-MM-dd'), [weekEnd]);
   const weekDays = useMemo(() => eachDayOfInterval({ start: weekStart, end: weekEnd }), [weekStart, weekEnd]);
   const mealTypes: MealType[] = useMemo(() => ['Desayuno', 'Almuerzo', 'Merienda', 'Cena'], []);
+  const weekRangeLabel = useMemo(
+    () => `${format(weekStart, 'd MMM', { locale: es })} - ${format(weekEnd, 'd MMM yyyy', { locale: es })}`,
+    [weekStart, weekEnd],
+  );
 
   // 2. Memorizar la función de organizar comidas
   // La función en sí ya está en useCallback, pero la hacemos más específica
@@ -151,6 +158,14 @@ const PlanningPage: React.FC = () => {
     setShowModal(true);
   }, []);
 
+  const goToPreviousWeek = useCallback(() => {
+    setCurrentDate(prevDate => addDays(prevDate, -7));
+  }, []);
+
+  const goToNextWeek = useCallback(() => {
+    setCurrentDate(prevDate => addDays(prevDate, 7));
+  }, []);
+
   // Manejar guardado de comidas
   const handleSaveMeal = useCallback(async (mealData: UpsertPlannedMealData) => {
     try {
@@ -174,10 +189,10 @@ const PlanningPage: React.FC = () => {
       setShowAutocompleteConfig(false);
       setIsGeneratingList(true); // Mostrar indicador de carga
       toast.success("Autocompletando semana...");
-      
+
       // Llamar a la función del store para autocompletar la semana
       await handleAutocompleteWeek(weekStartStr, weekEndStr, config);
-      
+
       toast.success("¡Semana autocompletada con éxito!");
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : "Error desconocido";
@@ -188,96 +203,82 @@ const PlanningPage: React.FC = () => {
     }
   }, [handleAutocompleteWeek, weekStartStr, weekEndStr]);
 
-  return (
-    <div className="flex flex-col items-center w-full h-full px-2 py-3 mx-auto">
-      {/* Header */}
-      <div className="flex flex-col items-center mb-4 w-full max-w-[1200px]">
-        <div className="flex items-center justify-between w-full px-4 py-2 bg-card rounded-lg shadow-sm">
-          <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setCurrentDate(prevDate => addDays(prevDate, -7))}
-              aria-label="Semana anterior"
-            >
-              <ChevronLeft className="h-5 w-5" />
-            </Button>
-            <div className="text-lg font-semibold">
-              {format(weekStart, 'd MMM', { locale: es })} - {format(weekEnd, 'd MMM yyyy', { locale: es })}
-            </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setCurrentDate(prevDate => addDays(prevDate, 7))}
-              aria-label="Semana siguiente"
-            >
-              <ChevronRight className="h-5 w-5" />
-            </Button>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button 
-              variant="outline" 
-              size="sm"
-              onClick={() => setShowAutocompleteConfig(true)}
-            >
-              <Sparkles className="h-4 w-4 mr-1" />
-              Autocompletar
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                if (confirm('¿Estás seguro de que quieres borrar todas las comidas de esta semana?')) {
-                  clearWeek(weekStartStr, weekEndStr);
-                }
-              }}
-            >
-              <Eraser className="h-4 w-4 mr-1" />
-              Limpiar Semana
-            </Button>
-          </div>
-        </div>
+  const handleClearWeek = useCallback(() => {
+    if (typeof window === 'undefined' || window.confirm('¿Estás seguro de que quieres borrar todas las comidas de esta semana?')) {
+      clearWeek(weekStartStr, weekEndStr);
+    }
+  }, [clearWeek, weekStartStr, weekEndStr]);
+
+  const headerActions = (
+    <div className="flex flex-wrap items-center gap-section-sm">
+      <div className="flex items-center gap-2 rounded-full border border-border bg-muted/50 px-2 py-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={goToPreviousWeek}
+          aria-label="Semana anterior"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <span className="px-2 text-sm font-medium text-muted-foreground">{weekRangeLabel}</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={goToNextWeek}
+          aria-label="Semana siguiente"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
       </div>
+      <div className="flex flex-wrap items-center gap-section-sm">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowAutocompleteConfig(true)}
+          disabled={isGeneratingList}
+        >
+          <Sparkles className="mr-2 h-4 w-4" />
+          Autocompletar
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleClearWeek}
+        >
+          <Eraser className="mr-2 h-4 w-4" />
+          Limpiar Semana
+        </Button>
+      </div>
+    </div>
+  );
 
-      {/* Content */}
-      {isLoading ? (
-        <div className="flex justify-center items-center h-64">
-          <Spinner size="lg" />
-        </div>
-      ) : (
-        <>
-          {/* Vista móvil */}
-          {!isDesktop && (
-            <div className="w-full max-w-[600px]">
-              <WeekDaySelector
-                days={weekDays}
-                selectedDay={selectedDate}
-                onDaySelect={setSelectedDate}
-              />
-              <div className="mt-4">
-                <PlanningDayView
-                  date={selectedDate}
-                  mealsByType={organizedMealsByDay[format(selectedDate, 'yyyy-MM-dd')] || {}}
-                  mealTypes={mealTypes}
-                  onAddClick={handleOpenAddModal}
-                  onEditClick={handleOpenEditModal}
-                  onDeleteClick={(mealId) => deletePlannedMeal(mealId)}
-                  onCopyClick={(meal) => setCopiedMeal(meal)}
-                />
-              </div>
+  return (
+    <>
+      <PageLayout
+        title="Planificación semanal"
+        description="Organiza tus comidas de la semana y mantén tu menú al día."
+        icon={<CalendarDays className="h-6 w-6" />}
+        actions={headerActions}
+        maxWidth="page"
+      >
+        <PageSection padded>
+          {isLoading ? (
+            <div className="flex h-64 w-full items-center justify-center">
+              <Spinner size="lg" />
             </div>
-          )}
-
-          {/* Vista de escritorio */}
-          {isDesktop && (
-            <div className="grid grid-cols-7 gap-4 w-full max-w-[1200px]">
-              {weekDays.map(day => {
-                const dateStr = format(day, 'yyyy-MM-dd');
-                return (
-                  <div key={dateStr} className="flex flex-col">
+          ) : (
+            <>
+              {!isDesktop && (
+                <div className="w-full max-w-md">
+                  <WeekDaySelector
+                    days={weekDays}
+                    selectedDay={selectedDate}
+                    onDaySelect={setSelectedDate}
+                  />
+                  <div className="mt-section-sm">
                     <PlanningDayView
-                      date={day}
-                      mealsByType={organizedMealsByDay[dateStr] || {}}
+                      date={selectedDate}
+                      mealsByType={organizedMealsByDay[format(selectedDate, 'yyyy-MM-dd')] || {}}
                       mealTypes={mealTypes}
                       onAddClick={handleOpenAddModal}
                       onEditClick={handleOpenEditModal}
@@ -285,14 +286,40 @@ const PlanningPage: React.FC = () => {
                       onCopyClick={(meal) => setCopiedMeal(meal)}
                     />
                   </div>
-                );
-              })}
-            </div>
-          )}
-        </>
-      )}
+                </div>
+              )}
 
-      {/* Modales */}
+              {isDesktop && (
+                <div className="grid w-full gap-section-sm md:grid-cols-7">
+                  {weekDays.map(day => {
+                    const dateStr = format(day, 'yyyy-MM-dd');
+                    return (
+                      <div key={dateStr} className="flex flex-col">
+                        <PlanningDayView
+                          date={day}
+                          mealsByType={organizedMealsByDay[dateStr] || {}}
+                          mealTypes={mealTypes}
+                          onAddClick={handleOpenAddModal}
+                          onEditClick={handleOpenEditModal}
+                          onDeleteClick={(mealId) => deletePlannedMeal(mealId)}
+                          onCopyClick={(meal) => setCopiedMeal(meal)}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </>
+          )}
+        </PageSection>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+      </PageLayout>
+
       <MealFormModal
         isOpen={showModal}
         onClose={() => {
@@ -314,13 +341,7 @@ const PlanningPage: React.FC = () => {
         isProcessing={isGeneratingList}
         initialConfig={{}}
       />
-
-      {error && (
-        <div className="mt-4 p-3 bg-red-50 text-red-800 rounded-md">
-          {error}
-        </div>
-      )}
-    </div>
+    </>
   );
 };
 

--- a/src/features/recipes/pages/RecipesPage.tsx
+++ b/src/features/recipes/pages/RecipesPage.tsx
@@ -5,8 +5,10 @@ import { useRecipeStore } from '@/stores/recipeStore';
 import RecipeGrid from '../components/RecipeGrid';
 import { Recipe } from '@/types/recipeTypes';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Plus } from 'lucide-react';
+import { BookOpen, Plus } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageSection } from '@/components/ui/PageSection';
 
 export default function RecipesPage() {
   const navigate = useNavigate();
@@ -39,44 +41,50 @@ export default function RecipesPage() {
     navigate(`/recipes/edit/${recipe.id}`);
   };
 
-  if (store.error) {
-    return (
-      <Alert variant="destructive" className="mb-4">
-        <AlertDescription>{store.error}</AlertDescription>
-      </Alert>
-    );
-  }
+  const actions = (
+    <Button onClick={() => navigate('/recipes/new')}>
+      <Plus className="mr-2 h-4 w-4" />
+      Nueva Receta
+    </Button>
+  );
+
+  const isInitialLoading = store.loading && store.recipes.length === 0;
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="flex justify-between items-center mb-8">
-        <h1 className="text-3xl font-bold">Mis Recetas</h1>
-        <Button onClick={() => navigate('/recipes/new')}>
-          <Plus className="h-4 w-4 mr-2" />
-          Nueva Receta
-        </Button>
-      </div>
+    <PageLayout
+      title="Mis Recetas"
+      description="Organiza tus recetas guardadas y añade nuevas creaciones."
+      icon={<BookOpen className="h-6 w-6" />}
+      actions={actions}
+    >
+      {store.error && (
+        <Alert variant="destructive">
+          <AlertDescription>{store.error}</AlertDescription>
+        </Alert>
+      )}
 
-      {store.loading && store.recipes.length === 0 ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          {[...Array(8)].map((_, i) => (
-            <div key={i} className="space-y-3">
-              <Skeleton className="h-48 w-full" />
-              <Skeleton className="h-4 w-3/4" />
-              <Skeleton className="h-4 w-1/2" />
-            </div>
-          ))}
-        </div>
-      ) : (
-        <>
-          <RecipeGrid
-            recipes={store.recipes}
-            onDelete={handleDelete}
-            onEdit={handleEdit}
-            onToggleFavorite={store.toggleFavorite}
-          />
-          {store.recipes.length > 0 && (
-            <div className="mt-8 text-center">
+      <PageSection padded>
+        {isInitialLoading && (
+          <div className="grid grid-cols-1 gap-section sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {[...Array(8)].map((_, index) => (
+              <div key={index} className="space-y-section-sm">
+                <Skeleton className="h-48 w-full rounded-2xl" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-1/2" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!isInitialLoading && store.recipes.length > 0 && (
+          <>
+            <RecipeGrid
+              recipes={store.recipes}
+              onDelete={handleDelete}
+              onEdit={handleEdit}
+              onToggleFavorite={store.toggleFavorite}
+            />
+            <div className="mt-section flex justify-center">
               <Button
                 variant="outline"
                 onClick={handleLoadMore}
@@ -85,20 +93,18 @@ export default function RecipesPage() {
                 {store.loading ? 'Cargando...' : 'Cargar más'}
               </Button>
             </div>
-          )}
-        </>
-      )}
+          </>
+        )}
 
-      {!store.loading && store.recipes.length === 0 && (
-        <div className="text-center py-12">
-          <p className="text-muted-foreground mb-4">
-            No hay recetas para mostrar
-          </p>
-          <Button onClick={() => navigate('/recipes/new')}>
-            Crear mi primera receta
-          </Button>
-        </div>
-      )}
-    </div>
+        {!isInitialLoading && store.recipes.length === 0 && (
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-muted/60 bg-muted/20 px-section py-section text-center">
+            <p className="mb-4 text-muted-foreground">No hay recetas para mostrar</p>
+            <Button onClick={() => navigate('/recipes/new')}>
+              Crear mi primera receta
+            </Button>
+          </div>
+        )}
+      </PageSection>
+    </PageLayout>
   );
 }

--- a/src/features/shopping-list/ShoppingListPage.tsx
+++ b/src/features/shopping-list/ShoppingListPage.tsx
@@ -2,9 +2,8 @@ import React, { useCallback, useEffect, useState, useMemo, useRef } from 'react'
 import { useAuth } from '@/features/auth/AuthContext'; // Importar useAuth
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/Spinner';
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { PriceResultsDisplay } from './components/PriceResultsDisplay'; // Recuperado
-import { SearchPanel } from './components/SearchPanel/SearchPanel'; // Recuperado
 import { ShoppingMap } from './components/Map/ShoppingMap'; // Recuperado
 import { FavoriteStoresInfo } from './components/Map/FavoriteStoresInfo'; // Recuperado
 import { searchProducts, BuscaPreciosProduct, SearchProductsResult } from './services/buscaPreciosService'; // Recuperado y añadido SearchProductsResult
@@ -26,7 +25,7 @@ import { useShoppingListStore } from '@/stores/shoppingListStore'; // Importar s
 import type { Database } from '@/lib/database.types'; // Importar tipos DB
 import { format, startOfWeek, endOfWeek } from 'date-fns';
 import { es } from 'date-fns/locale';
-import { ListChecks, Terminal, Trash2, XCircle, Search } from 'lucide-react'; // Añadir icono Search
+import { ListChecks, ListPlus, Trash2, XCircle, Search } from 'lucide-react'; // Añadir iconos
 import { parseShoppingInput, ParsedShoppingInput } from './lib/inputParser'; // Importar parser
 import { supabase } from '@/lib/supabaseClient'; // Importar supabase directamente
 import ResponsiveLayout from './components/Layout/ResponsiveLayout'; // IMPORTAR RESPONSIVE LAYOUT
@@ -34,6 +33,8 @@ import { getDisplayCategory } from './utils/categorization'; // Importar la func
 // --- NUEVO: Importar componentes de Tabs ---
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { cn } from '@/lib/utils'; // Importar la función de utilidades
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageSection } from '@/components/ui/PageSection';
 
 // --- ANALYTICS HELPER ---
 // Función para categorizar el número de resultados (Paso 2.2)
@@ -456,7 +457,7 @@ const handleToggleItem = useCallback(async (itemId: string, currentStatus: boole
 
   // Función para renderizar el contenido principal (MODIFICADA para pasar categorías)
   const renderShoppingListContent = () => (
-    <div className="flex flex-col h-full flex-grow"> 
+    <div className="flex flex-col h-full flex-grow">
       <div className="p-4 pb-2 flex-shrink-0"> {/* Reducir padding inferior, evitar encogimiento */}
         <AddItemForm 
           onAddItem={async (parsedItem) => { 
@@ -597,14 +598,42 @@ const handleToggleItem = useCallback(async (itemId: string, currentStatus: boole
   // Bloque eliminado ya que fue movido arriba
 
   // Renderizar el layout según el breakpoint (Recuperado y adaptado)
-  return (
-    <div className="h-screen flex flex-col"> {/* Ocupar toda la altura */}
-      <ResponsiveLayout
-        shoppingList={renderShoppingListContent()} // Pasar el contenido de la lista unificada
-        map={mapContent} // Pasar el contenido del mapa
-        // searchPanel ya no se pasa
-      />
+  const headerActions = (
+    <div className="flex flex-wrap items-center gap-section-sm">
+      <Button
+        onClick={handleGenerateList}
+        disabled={isLoading}
+      >
+        <ListPlus className="mr-2 h-4 w-4" />
+        Generar semana
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleSearchAllPrices}
+        disabled={isSearchingPrices || listItems.length === 0}
+      >
+        <Search className="mr-2 h-4 w-4" />
+        Buscar precios
+      </Button>
     </div>
+  );
+
+  return (
+    <PageLayout
+      title="Lista de compras inteligente"
+      description="Centraliza tu lista semanal, resultados de precios y mapa de tiendas favoritas."
+      icon={<ListChecks className="h-6 w-6" />}
+      actions={headerActions}
+      maxWidth="full"
+    >
+      <PageSection padded={false} className="overflow-hidden min-h-[60vh]" contentClassName="p-0">
+        <ResponsiveLayout
+          shoppingList={renderShoppingListContent()}
+          map={mapContent}
+        />
+      </PageSection>
+    </PageLayout>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -61,9 +61,16 @@ body, #root {
   --destructive-foreground: 0 80% 98%; /* Blanco muy claro */
 
   /* Teal más oscuro para focus ring */
-  --ring: 170 50% 40%;       
+  --ring: 170 50% 40%;
 
-  --radius: 0.5rem;          
+  --radius: 0.5rem;
+  --spacing-page-inline: clamp(1.5rem, 4vw, 2.75rem);
+  --spacing-page-block: clamp(1.5rem, 5vw, 3.5rem);
+  --spacing-section-sm: 0.75rem;
+  --spacing-section: 1.5rem;
+  --spacing-section-lg: 2rem;
+  --max-width-page: 1200px;
+  --max-width-content: 1040px;
 }
 
 .dark {
@@ -100,7 +107,15 @@ body, #root {
   --destructive-foreground: 0 80% 98%; /* Blanco muy claro */
 
   /* Teal más claro para focus ring en oscuro */
-  --ring: 170 60% 55%;        
+  --ring: 170 60% 55%;
+
+  --spacing-page-inline: clamp(1.5rem, 4vw, 2.75rem);
+  --spacing-page-block: clamp(1.5rem, 5vw, 3.5rem);
+  --spacing-section-sm: 0.75rem;
+  --spacing-section: 1.5rem;
+  --spacing-section-lg: 2rem;
+  --max-width-page: 1200px;
+  --max-width-content: 1040px;
 }
 
 @layer base {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,108 +1,54 @@
 /** @type {import('tailwindcss').Config} */
 import defaultTheme from 'tailwindcss/defaultTheme';
+import themeTokens from './design-tokens.js';
+
+const { colors, spacing, radii, maxWidth } = themeTokens;
 
 export default {
-  darkMode: ["class"],
-  content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-  	container: {
-  		center: true,
-  		padding: '2rem',
-  		screens: {
-  			'2xl': '1400px'
-  		}
-  	},
-  	extend: {
-  		fontFamily: {
-  			sans: [
-  				'Poppins',
-                    ...defaultTheme.fontFamily.sans
-                ]
-  		},
-  		colors: {
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			}
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			},
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out',
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		}
-  	}
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
+    },
+    extend: {
+      fontFamily: {
+        sans: ['Poppins', ...defaultTheme.fontFamily.sans],
+      },
+      colors: {
+        ...colors,
+      },
+      spacing: {
+        ...spacing,
+      },
+      borderRadius: {
+        xl: radii.lg,
+        lg: radii.base,
+        md: `calc(${radii.base} - 2px)`,
+        sm: `calc(${radii.base} - 4px)`,
+      },
+      maxWidth: {
+        ...maxWidth,
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
   },
-  plugins: [require("tailwindcss-animate")],
-}
+  plugins: [require('tailwindcss-animate')],
+};


### PR DESCRIPTION
## Summary
- centralize color and spacing tokens for Tailwind and the runtime theme configuration
- introduce shared PageLayout/PageSection components and apply them to Pantry, Planning, Recipes, and Shopping List pages
- document the new layout patterns and add Storybook configuration with layout stories for visual regression coverage

## Testing
- `npm run test -- --watch=false` *(fails: existing jest suite errors and naming collisions)*

------
https://chatgpt.com/codex/tasks/task_e_68f2992928e08320a67bbfe9a47b61c0