### PR TITLE
feat: add AI suggestions engine and page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { AppLayout } from './components/layout/AppLayout'
 import { Spinner } from './components/ui/Spinner'
 import { useSettings } from './context/SettingsContext'
 import { LazyLandingComponents, LazyAuth, LazyFeatures } from '@/components/lazyComponents'
+import { featureFlags } from '@/config/featureFlags'
 
 // Componentes no lazy (usados en múltiples rutas o pequeños)
 import Navbar from './components/sections/Navbar'
@@ -204,6 +205,16 @@ function App() {
               <LazyFeatures.AddEditRecipePage />
             </Suspense>
           } />
+          {featureFlags.aiSuggestions && (
+            <Route
+              path="suggestions"
+              element={
+                <Suspense fallback={<PageLoader />}>
+                  <LazyFeatures.SuggestionsPage />
+                </Suspense>
+              }
+            />
+          )}
           <Route path="recipes/:recipeId" element={
             <Suspense fallback={<PageLoader />}>
               <LazyFeatures.RecipeDetailPage />

--- a/src/components/layout/BottomNavBar.tsx
+++ b/src/components/layout/BottomNavBar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { Home, ShoppingBasket, CalendarDays, ListChecks, BookOpen, Star } from 'lucide-react'; // Añadir Star
+import { Home, ShoppingBasket, CalendarDays, ListChecks, BookOpen, Star, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button'; // Importar Button si se usa como base
+import { featureFlags } from '@/config/featureFlags';
 
 // Definir los items principales para la barra inferior (máximo 5 recomendados)
 const bottomNavigation = [
@@ -11,6 +11,9 @@ const bottomNavigation = [
   { name: 'Plan', href: '/app/planning', icon: CalendarDays },
   { name: 'Lista', href: '/app/shopping-list', icon: ListChecks },
   { name: 'Recetas', href: '/app/recipes', icon: BookOpen },
+  ...(featureFlags.aiSuggestions
+    ? [{ name: 'Ideas', href: '/app/suggestions', icon: Sparkles }]
+    : []),
 ];
 
 interface BottomNavBarProps {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,10 +1,22 @@
 // src/components/layout/Sidebar.tsx
 import { NavLink, Link } from 'react-router-dom';
 import { Logo } from '@/components/common/Logo';
-import { Home, BookOpen, ShoppingBasket, CalendarDays, User, ListChecks, PanelLeftClose, PanelLeftOpen, Star } from 'lucide-react'; // Añadir Star
+import {
+  Home,
+  BookOpen,
+  ShoppingBasket,
+  CalendarDays,
+  User,
+  ListChecks,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Star,
+  Sparkles,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { motion } from 'framer-motion';
+import { featureFlags } from '@/config/featureFlags';
 
 const navigation = [
   { name: 'Dashboard', href: '/app', icon: Home, exact: true },
@@ -13,6 +25,9 @@ const navigation = [
   { name: 'Planificación', href: '/app/planning', icon: CalendarDays },
   { name: 'Lista Compras', href: '/app/shopping-list', icon: ListChecks },
   { name: 'Perfil', href: '/app/profile', icon: User },
+  ...(featureFlags.aiSuggestions
+    ? [{ name: 'Sugerencias IA', href: '/app/suggestions', icon: Sparkles }]
+    : []),
 ];
 
 interface SidebarProps {

--- a/src/components/lazyComponents.tsx
+++ b/src/components/lazyComponents.tsx
@@ -10,7 +10,8 @@ export const LazyFeatures = {
   ShoppingListPage: lazy(() => import('@/features/shopping-list/ShoppingListPage')),
   RecipeListPage: lazy(() => import('@/features/recipes/pages/RecipeListPage')),
   AddEditRecipePage: lazy(() => import('@/features/recipes/pages/AddEditRecipePage')),
-  RecipeDetailPage: lazy(() => import('@/features/recipes/pages/RecipeDetailPage'))
+  RecipeDetailPage: lazy(() => import('@/features/recipes/pages/RecipeDetailPage')),
+  SuggestionsPage: lazy(() => import('@/features/suggestions/pages/SuggestionsPage')),
 };
 
 export const LazyLandingComponents = {};

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,0 +1,25 @@
+export interface FeatureFlagsConfig {
+  aiSuggestions: boolean;
+}
+
+function booleanFromEnv(value: unknown, defaultValue = false): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+    if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+  }
+  return defaultValue;
+}
+
+export const featureFlags: FeatureFlagsConfig = {
+  aiSuggestions: booleanFromEnv(import.meta.env.VITE_ENABLE_AI_SUGGESTIONS, false),
+};
+
+export type FeatureFlagKey = keyof FeatureFlagsConfig;
+
+export function isFeatureEnabled(flag: FeatureFlagKey): boolean {
+  return featureFlags[flag];
+}

--- a/src/features/suggestions/pages/SuggestionsPage.tsx
+++ b/src/features/suggestions/pages/SuggestionsPage.tsx
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { format, startOfWeek, endOfWeek } from 'date-fns';
+import { Sparkles, CalendarPlus, BookmarkPlus, Loader2 } from 'lucide-react';
+import { PageHeader } from '@/components/ui/PageHeader';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/Spinner';
+import { useSuggestionStore } from '../stores/suggestionStore';
+import { usePantryStore } from '@/stores/pantryStore';
+import { useRecipeStore } from '@/stores/recipeStore';
+import { usePlanningStore } from '@/stores/planningStore';
+import { useAuth } from '@/features/auth/AuthContext';
+import { toast } from 'sonner';
+import type { MealType } from '@/features/planning/types';
+import type { RecipeSuggestion } from '../types';
+import { featureFlags } from '@/config/featureFlags';
+
+const mealTypes: MealType[] = ['Desayuno', 'Almuerzo', 'Merienda', 'Cena'];
+
+const SuggestionsPage = () => {
+  const [selectedMealType, setSelectedMealType] = useState<MealType>('Almuerzo');
+  const [selectedDate, setSelectedDate] = useState<string>(() => format(new Date(), 'yyyy-MM-dd'));
+  const [maxTime, setMaxTime] = useState<string>('');
+  const [isInitializing, setIsInitializing] = useState(true);
+
+  const { user } = useAuth();
+
+  const pantryItems = usePantryStore((state) => state.items);
+  const fetchPantryItems = usePantryStore((state) => state.fetchItems);
+  const pantryIsLoading = usePantryStore((state) => state.isLoading);
+
+  const recipes = useRecipeStore((state) => state.recipes);
+  const loadRecipes = useRecipeStore((state) => state.loadRecipes);
+  const toggleRecipeFavorite = useRecipeStore((state) => state.toggleFavorite);
+  const recipesAreLoading = useRecipeStore((state) => state.isLoading);
+
+  const plannedMeals = usePlanningStore((state) => state.plannedMeals);
+  const loadPlannedMeals = usePlanningStore((state) => state.loadPlannedMeals);
+  const addPlannedMeal = usePlanningStore((state) => state.addPlannedMeal);
+  const planningIsLoading = usePlanningStore((state) => state.isLoading);
+
+  const suggestions = useSuggestionStore((state) => state.suggestions);
+  const suggestionsAreLoading = useSuggestionStore((state) => state.isLoading);
+  const suggestionsError = useSuggestionStore((state) => state.error);
+  const lastUpdated = useSuggestionStore((state) => state.lastUpdated);
+  const requestSuggestions = useSuggestionStore((state) => state.getSuggestions);
+  const clearSuggestionsError = useSuggestionStore((state) => state.clearError);
+
+  const recipesById = useMemo(() => new Map(recipes.map((recipe) => [recipe.id, recipe])), [recipes]);
+
+  const weekWindow = useMemo(() => {
+    const baseDate = selectedDate ? new Date(selectedDate) : new Date();
+    const start = startOfWeek(baseDate, { weekStartsOn: 1 });
+    const end = endOfWeek(baseDate, { weekStartsOn: 1 });
+    return {
+      start: format(start, 'yyyy-MM-dd'),
+      end: format(end, 'yyyy-MM-dd'),
+    };
+  }, [selectedDate]);
+
+  useEffect(() => {
+    if (!featureFlags.aiSuggestions) {
+      return;
+    }
+    if (user) {
+      fetchPantryItems();
+    }
+  }, [user, fetchPantryItems]);
+
+  useEffect(() => {
+    if (!featureFlags.aiSuggestions) {
+      return;
+    }
+    if (user?.id && recipes.length === 0 && !recipesAreLoading) {
+      loadRecipes(user.id, true);
+    }
+  }, [user?.id, recipes.length, recipesAreLoading, loadRecipes]);
+
+  useEffect(() => {
+    if (!featureFlags.aiSuggestions) {
+      return;
+    }
+    if (user && weekWindow.start && weekWindow.end) {
+      loadPlannedMeals(weekWindow.start, weekWindow.end);
+    }
+  }, [user, weekWindow.start, weekWindow.end, loadPlannedMeals]);
+
+  useEffect(() => {
+    if (!featureFlags.aiSuggestions) {
+      return;
+    }
+    if (!pantryIsLoading && !recipesAreLoading && !planningIsLoading) {
+      setIsInitializing(false);
+    }
+  }, [pantryIsLoading, recipesAreLoading, planningIsLoading]);
+
+  useEffect(() => {
+    if (suggestionsError) {
+      toast.error(suggestionsError);
+    }
+  }, [suggestionsError]);
+
+  const handleGenerateSuggestions = useCallback(async () => {
+    clearSuggestionsError();
+    const maxTimeNumber = maxTime ? Number(maxTime) : undefined;
+    await requestSuggestions({
+      mealType: selectedMealType,
+      maxTime: Number.isFinite(maxTimeNumber) ? maxTimeNumber : undefined,
+      targetDate: selectedDate,
+      context: {
+        pantryItems,
+        recipes,
+        plannedMeals,
+      },
+    });
+  }, [clearSuggestionsError, maxTime, requestSuggestions, selectedMealType, selectedDate, pantryItems, recipes, plannedMeals]);
+
+  const handleAddToPlan = useCallback(async (suggestion: RecipeSuggestion) => {
+    try {
+      const planDate = selectedDate || format(new Date(), 'yyyy-MM-dd');
+      const payload = suggestion.id
+        ? {
+            plan_date: planDate,
+            meal_type: selectedMealType,
+            recipe_id: suggestion.id,
+            notes: suggestion.reason ?? suggestion.description ?? undefined,
+          }
+        : {
+            plan_date: planDate,
+            meal_type: selectedMealType,
+            custom_meal_name: suggestion.title ?? suggestion.name ?? 'Sugerencia IA',
+            notes: suggestion.reason ?? suggestion.description ?? undefined,
+          };
+      const result = await addPlannedMeal(payload);
+      if (result) {
+        toast.success('Sugerencia añadida al plan semanal');
+      } else {
+        toast.error('No se pudo añadir la sugerencia al plan');
+      }
+    } catch (error) {
+      console.error('Error añadiendo sugerencia al plan', error);
+      toast.error('Ocurrió un error al añadir la sugerencia');
+    }
+  }, [addPlannedMeal, selectedDate, selectedMealType]);
+
+  const handleToggleFavorite = useCallback(async (suggestion: RecipeSuggestion) => {
+    if (!suggestion.id) {
+      toast.info('Guarda la receta en tu biblioteca para marcarla como favorita.');
+      return;
+    }
+    const recipe = recipesById.get(suggestion.id);
+    if (!recipe) {
+      toast.error('La receta no está disponible en tu biblioteca.');
+      return;
+    }
+    try {
+      await toggleRecipeFavorite(suggestion.id, !recipe.is_favorite);
+      toast.success(!recipe.is_favorite ? 'Receta marcada como favorita' : 'Receta removida de favoritos');
+    } catch (error) {
+      console.error('Error actualizando favorito', error);
+      toast.error('No se pudo actualizar el estado de favorito');
+    }
+  }, [recipesById, toggleRecipeFavorite]);
+
+  if (!featureFlags.aiSuggestions) {
+    return (
+      <div className="max-w-3xl mx-auto space-y-6">
+        <PageHeader
+          title="Sugerencias con IA"
+          description="Activa la bandera de características para habilitar las recomendaciones inteligentes."
+          icon={<Sparkles className="h-6 w-6" />}
+        />
+        <Alert>
+          <AlertTitle>Funcionalidad en pruebas</AlertTitle>
+          <AlertDescription>
+            El experimento de sugerencias con IA está desactivado. Contacta al equipo de producto para habilitarlo.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (isInitializing) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[320px] space-y-4">
+        <Spinner size="lg" />
+        <p className="text-sm text-muted-foreground">Preparando tu contexto de recetas e inventario…</p>
+      </div>
+    );
+  }
+
+  const lastUpdatedLabel = lastUpdated
+    ? `${format(lastUpdated, 'HH:mm')} hs`
+    : 'Aún no has generado sugerencias';
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Sugerencias con IA"
+        description="Combina tu despensa, recetas y plan actual para descubrir qué cocinar hoy."
+        icon={<Sparkles className="h-6 w-6 text-primary" />}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Configura tu búsqueda</CardTitle>
+          <CardDescription>Ajusta los parámetros para personalizar las sugerencias generadas.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-3">
+          <div className="space-y-2">
+            <Label htmlFor="target-date">Fecha objetivo</Label>
+            <Input
+              id="target-date"
+              type="date"
+              value={selectedDate}
+              onChange={(event) => setSelectedDate(event.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="meal-type">Tipo de comida</Label>
+            <Select value={selectedMealType} onValueChange={(value) => setSelectedMealType(value as MealType)}>
+              <SelectTrigger id="meal-type">
+                <SelectValue placeholder="Selecciona el tipo de comida" />
+              </SelectTrigger>
+              <SelectContent>
+                {mealTypes.map((type) => (
+                  <SelectItem key={type} value={type}>
+                    {type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="max-time">Tiempo máximo (minutos)</Label>
+            <Input
+              id="max-time"
+              type="number"
+              min={0}
+              placeholder="Opcional"
+              value={maxTime}
+              onChange={(event) => setMaxTime(event.target.value)}
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="text-sm text-muted-foreground">{lastUpdatedLabel}</div>
+          <Button
+            onClick={handleGenerateSuggestions}
+            disabled={suggestionsAreLoading}
+            className="inline-flex items-center gap-2"
+          >
+            {suggestionsAreLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4" />
+            )}
+            Generar sugerencias
+          </Button>
+        </CardFooter>
+      </Card>
+
+      {suggestionsAreLoading && (
+        <div className="flex items-center justify-center py-12">
+          <Spinner size="md" />
+        </div>
+      )}
+
+      {!suggestionsAreLoading && suggestions.length === 0 && (
+        <Card className="border-dashed">
+          <CardHeader>
+            <CardTitle>Sin sugerencias todavía</CardTitle>
+            <CardDescription>
+              Genera sugerencias para ver recomendaciones basadas en tu despensa y tu plan semanal.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {suggestions.map((suggestion) => (
+          <Card key={suggestion.id ?? suggestion.title ?? suggestion.name} className="h-full flex flex-col">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle>{suggestion.title ?? suggestion.name}</CardTitle>
+                  {suggestion.reason && (
+                    <p className="mt-2 text-sm text-muted-foreground">{suggestion.reason}</p>
+                  )}
+                </div>
+                <Badge variant="secondary">IA</Badge>
+              </div>
+              {suggestion.estimatedTime && (
+                <CardDescription>Listo en {suggestion.estimatedTime}</CardDescription>
+              )}
+            </CardHeader>
+            <CardContent className="flex-1 space-y-4">
+              {suggestion.description && (
+                <p className="text-sm leading-relaxed text-muted-foreground">{suggestion.description}</p>
+              )}
+              {suggestion.ingredients?.length ? (
+                <div>
+                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Ingredientes clave</p>
+                  <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+                    {suggestion.ingredients.slice(0, 6).map((ingredient) => (
+                      <li key={ingredient} className="flex items-center gap-2">
+                        <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                        {ingredient}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </CardContent>
+            <CardFooter className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                className="flex-1"
+                onClick={() => handleAddToPlan(suggestion)}
+                variant="default"
+              >
+                <CalendarPlus className="mr-2 h-4 w-4" /> Añadir al plan
+              </Button>
+              <Button
+                className="flex-1"
+                onClick={() => handleToggleFavorite(suggestion)}
+                variant="outline"
+              >
+                <BookmarkPlus className="mr-2 h-4 w-4" /> Favorita
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SuggestionsPage;

--- a/src/features/suggestions/services/suggestionService.ts
+++ b/src/features/suggestions/services/suggestionService.ts
@@ -1,118 +1,23 @@
-import { GoogleGenerativeAI } from "@google/generative-ai";
-import { SuggestionRequest, SuggestionResponse, RecipeSuggestion } from '../types';
+import { suggestionEngine } from '@/lib/suggestions/SuggestionEngine';
+import type { SuggestionRequest, SuggestionResponse } from '../types';
 
 /**
- * Servicio para manejar las sugerencias de recetas usando IA
+ * Servicio para manejar las sugerencias de recetas usando IA o fallbacks locales
  */
 class SuggestionService {
-  private apiKey: string | null = null;
-  private genAI: GoogleGenerativeAI | null = null;
-
-  /**
-   * Obtiene la clave API de Gemini desde el servidor
-   * @returns La clave API
-   * @throws Error si no se puede obtener la clave
-   */
-  private async fetchGeminiApiKey(): Promise<string> {
-    const response = await fetch('/api/get-gemini-key', {
-      headers: {
-        'Authorization': `Bearer ${localStorage.getItem('sb-access-token')}`
-      }
-    });
-
-    if (!response.ok) {
-      throw new Error('No se pudo obtener la clave API de Gemini');
-    }
-
-    const data = await response.json();
-    return data.apiKey;
-  }
-
-  /**
-   * Construye el prompt para Gemini basado en los ingredientes y preferencias
-   */
-  private buildPrompt(request: SuggestionRequest): string {
-    const { pantryItems, dietary, maxTime } = request;
-    
-    let prompt = `Actúa como un chef experto y sugiere 3 recetas utilizando algunos o todos estos ingredientes disponibles:\n`;
-    
-    // Lista de ingredientes
-    pantryItems.forEach(item => {
-      prompt += `- ${item.name} (${item.quantity}${item.unit ? ' ' + item.unit : ''})\n`;
-    });
-
-    // Restricciones dietéticas
-    if (dietary) {
-      if (dietary.vegetarian) prompt += '\nLas recetas deben ser vegetarianas.';
-      if (dietary.vegan) prompt += '\nLas recetas deben ser veganas.';
-      if (dietary.glutenFree) prompt += '\nLas recetas deben ser sin gluten.';
-    }
-
-    // Tiempo máximo
-    if (maxTime) {
-      prompt += `\nLas recetas no deben tomar más de ${maxTime} minutos en prepararse.`;
-    }
-
-    prompt += `\n\nPor favor, devuelve las sugerencias en este formato JSON exacto:
-{
-  "suggestions": [
-    {
-      "name": "Nombre de la Receta",
-      "description": "Breve descripción y pasos principales",
-      "estimatedTime": "XX minutos",
-      "difficulty": "fácil|media|difícil",
-      "ingredients": ["ingrediente 1", "ingrediente 2"]
-    }
-  ]
-}`;
-
-    return prompt;
-  }
-
-  /**
-   * Inicializa o actualiza el cliente de Gemini
-   * @throws Error si no se puede inicializar
-   */
-  private async initializeGenAI(): Promise<void> {
-    if (!this.apiKey) {
-      this.apiKey = await this.fetchGeminiApiKey();
-      this.genAI = new GoogleGenerativeAI(this.apiKey);
-    }
-  }
-
-  /**
-   * Obtiene sugerencias de recetas basadas en los ingredientes disponibles
-   * @param request Detalles de la solicitud de sugerencias
-   * @returns Lista de sugerencias de recetas
-   */
   public async getSuggestions(request: SuggestionRequest): Promise<SuggestionResponse> {
     try {
-      await this.initializeGenAI();
-      
-      if (!this.genAI) {
-        throw new Error('No se pudo inicializar el cliente de Gemini');
-      }
-
-      const model = this.genAI.getGenerativeModel({ model: "gemini-pro" });
-      
-      const prompt = this.buildPrompt(request);
-      const result = await model.generateContent(prompt);
-      const response = await result.response;
-      const text = response.text();
-
-      // Intentar parsear la respuesta JSON
-      try {
-        const parsedResponse = JSON.parse(text);
-        return parsedResponse as SuggestionResponse;
-      } catch (error) {
-        console.error('Error parseando respuesta de Gemini:', error);
-        throw new Error('La respuesta de IA no tiene el formato esperado');
-      }
+      const context = request.context ?? { pantryItems: [], recipes: [], plannedMeals: [] };
+      return await suggestionEngine.generateSuggestions(request, {
+        pantryItems: context.pantryItems ?? [],
+        recipes: context.recipes ?? [],
+        plannedMeals: context.plannedMeals ?? [],
+      });
     } catch (error) {
       console.error('Error en getSuggestions:', error);
       return {
         suggestions: [],
-        error: error instanceof Error ? error.message : 'Error desconocido'
+        error: error instanceof Error ? error.message : 'Error desconocido',
       };
     }
   }

--- a/src/features/suggestions/types.ts
+++ b/src/features/suggestions/types.ts
@@ -14,8 +14,18 @@ export interface SuggestionResponse {
   error?: string;
 }
 
+import type { PantryItem } from '@/features/pantry/types';
+import type { PlannedMeal } from '@/features/planning/types';
+import type { Recipe } from '@/types/recipeTypes';
+
+export interface SuggestionContextSnapshot {
+  pantryItems: PantryItem[];
+  recipes: Recipe[];
+  plannedMeals: PlannedMeal[];
+}
+
 export interface SuggestionRequest {
-  pantryItems: {
+  pantryItems?: {
     name: string;
     quantity: number;
     unit?: string;
@@ -27,6 +37,8 @@ export interface SuggestionRequest {
   };
   maxTime?: number; // en minutos
   mealType?: string; // Tipo de comida (Desayuno, Almuerzo, etc.)
+  targetDate?: string; // Fecha sugerida para la planificación
+  context?: Partial<SuggestionContextSnapshot>;
 }
 
 // Interfaz necesaria para SuggestionsPopover

--- a/src/lib/ai/aiClient.ts
+++ b/src/lib/ai/aiClient.ts
@@ -1,0 +1,114 @@
+import type { SuggestionResponse } from '@/features/suggestions/types';
+
+export type AiProviderName = 'mock' | 'proxy';
+
+export interface AiClientOptions {
+  provider?: AiProviderName;
+  proxyUrl?: string;
+  defaultHeaders?: Record<string, string>;
+}
+
+export interface AiStructuredRequest<T> {
+  prompt: string;
+  context?: Record<string, unknown>;
+  fallback: T;
+  signal?: AbortSignal;
+}
+
+interface AiProvider {
+  generateStructuredResponse<T>(request: AiStructuredRequest<T>): Promise<T>;
+}
+
+class MockAiProvider implements AiProvider {
+  async generateStructuredResponse<T>(request: AiStructuredRequest<T>): Promise<T> {
+    const mockResponse = request.context?.mockResponse as T | undefined;
+    return mockResponse ?? request.fallback;
+  }
+}
+
+class ProxyAiProvider implements AiProvider {
+  private proxyUrl?: string;
+  private defaultHeaders: Record<string, string>;
+
+  constructor(options: AiClientOptions) {
+    this.proxyUrl = options.proxyUrl;
+    this.defaultHeaders = options.defaultHeaders ?? {};
+  }
+
+  async generateStructuredResponse<T>(request: AiStructuredRequest<T>): Promise<T> {
+    if (!this.proxyUrl) {
+      throw new Error('AI proxy URL is not configured.');
+    }
+
+    const response = await fetch(this.proxyUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...this.defaultHeaders,
+      },
+      body: JSON.stringify({
+        prompt: request.prompt,
+        context: request.context,
+      }),
+      signal: request.signal,
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(`AI proxy request failed: ${message || response.statusText}`);
+    }
+
+    const data = (await response.json()) as T;
+    return data;
+  }
+}
+
+export class ConfigurableAiClient {
+  private provider: AiProvider;
+  private options: AiClientOptions;
+
+  constructor(options: AiClientOptions = {}) {
+    this.options = options;
+    this.provider = this.createProvider(options);
+  }
+
+  setProvider(provider: AiProviderName, options: Partial<AiClientOptions> = {}): void {
+    this.options = { ...this.options, provider, ...options };
+    this.provider = this.createProvider(this.options);
+  }
+
+  async generateStructuredResponse<T>(request: AiStructuredRequest<T>): Promise<T> {
+    try {
+      return await this.provider.generateStructuredResponse(request);
+    } catch (error) {
+      console.warn('[aiClient] Falling back to provided data due to provider error:', error);
+      return request.fallback;
+    }
+  }
+
+  private createProvider(options: AiClientOptions): AiProvider {
+    switch (options.provider) {
+      case 'proxy':
+        return new ProxyAiProvider(options);
+      case 'mock':
+      default:
+        return new MockAiProvider();
+    }
+  }
+}
+
+const providerFromEnv = (import.meta.env.VITE_AI_PROVIDER as AiProviderName | undefined) ?? 'mock';
+const proxyUrlFromEnv = import.meta.env.VITE_AI_PROXY_URL as string | undefined;
+const defaultHeaders: Record<string, string> = {};
+
+export const aiClient = new ConfigurableAiClient({
+  provider: providerFromEnv,
+  proxyUrl: proxyUrlFromEnv,
+  defaultHeaders,
+});
+
+export async function generateSuggestionsWithFallback(
+  request: AiStructuredRequest<SuggestionResponse>,
+): Promise<SuggestionResponse> {
+  return aiClient.generateStructuredResponse<SuggestionResponse>(request);
+}

--- a/src/lib/suggestions/SuggestionEngine.ts
+++ b/src/lib/suggestions/SuggestionEngine.ts
@@ -1,0 +1,301 @@
+import { differenceInCalendarDays } from 'date-fns';
+import type { PantryItem } from '@/features/pantry/types';
+import type { PlannedMeal, MealType } from '@/features/planning/types';
+import type { Recipe, RecipeIngredient } from '@/types/recipeTypes';
+import type { SuggestionRequest, SuggestionResponse, RecipeSuggestion } from '@/features/suggestions/types';
+import { generateSuggestionsWithFallback } from '@/lib/ai/aiClient';
+
+interface PantrySummaryItem {
+  name: string;
+  quantity?: number | null;
+  unit?: string | null;
+  isFavorite?: boolean;
+  category?: string | null;
+}
+
+interface RecipeSummaryItem {
+  id: string;
+  title: string;
+  description?: string | null;
+  isFavorite: boolean;
+  totalTime?: number | null;
+  tags?: string[];
+  mainIngredients: string[];
+  lastPlannedDate?: string | null;
+}
+
+interface PlanningSummaryItem {
+  plan_date: string;
+  meal_type: MealType;
+  recipe_id?: string | null;
+  custom_meal_name?: string | null;
+}
+
+export interface SuggestionEngineContextInput {
+  pantryItems: PantryItem[];
+  recipes: Recipe[];
+  plannedMeals: PlannedMeal[];
+}
+
+interface SuggestionEngineContext {
+  pantry: PantrySummaryItem[];
+  recipes: RecipeSummaryItem[];
+  planning: PlanningSummaryItem[];
+}
+
+interface SuggestionEngineOptions {
+  maxSuggestions?: number;
+}
+
+export class SuggestionEngine {
+  private maxSuggestions: number;
+
+  constructor(options: SuggestionEngineOptions = {}) {
+    this.maxSuggestions = options.maxSuggestions ?? 3;
+  }
+
+  async generateSuggestions(
+    request: SuggestionRequest,
+    contextInput: SuggestionEngineContextInput,
+  ): Promise<SuggestionResponse> {
+    const context = this.buildContext(contextInput);
+    const prompt = this.buildPrompt(request, context);
+    const fallback: SuggestionResponse = {
+      suggestions: this.buildFallbackSuggestions(request, context),
+    };
+
+    return generateSuggestionsWithFallback({
+      prompt,
+      context: {
+        request,
+        pantry: context.pantry,
+        recipes: context.recipes,
+        planning: context.planning,
+      },
+      fallback,
+    });
+  }
+
+  private buildContext(input: SuggestionEngineContextInput): SuggestionEngineContext {
+    const pantry: PantrySummaryItem[] = input.pantryItems.map((item) => ({
+      name: item.ingredient?.name ?? item.notes ?? 'Item sin nombre',
+      quantity: item.quantity,
+      unit: item.unit,
+      isFavorite: Boolean(item.is_favorite),
+      category: item.category?.name ?? null,
+    }));
+
+    const planning: PlanningSummaryItem[] = input.plannedMeals.map((meal) => ({
+      plan_date: meal.plan_date,
+      meal_type: meal.meal_type,
+      recipe_id: meal.recipe_id ?? undefined,
+      custom_meal_name: meal.custom_meal_name ?? undefined,
+    }));
+
+    const lastPlannedByRecipe = new Map<string, string>();
+    for (const meal of planning) {
+      if (meal.recipe_id) {
+        const existing = lastPlannedByRecipe.get(meal.recipe_id);
+        if (!existing || existing < meal.plan_date) {
+          lastPlannedByRecipe.set(meal.recipe_id, meal.plan_date);
+        }
+      }
+    }
+
+    const recipes: RecipeSummaryItem[] = input.recipes.map((recipe) => ({
+      id: recipe.id,
+      title: recipe.title,
+      description: recipe.description ?? undefined,
+      isFavorite: Boolean(recipe.is_favorite),
+      totalTime:
+        (recipe.prep_time_minutes ?? 0) + (recipe.cook_time_minutes ?? 0) || null,
+      tags: recipe.tags ?? undefined,
+      mainIngredients: this.extractRecipeIngredients(recipe.recipe_ingredients),
+      lastPlannedDate: lastPlannedByRecipe.get(recipe.id) ?? null,
+    }));
+
+    return { pantry, recipes, planning };
+  }
+
+  private buildPrompt(request: SuggestionRequest, context: SuggestionEngineContext): string {
+    const sections: string[] = [];
+
+    sections.push(
+      'Eres un asistente culinario que ayuda a planificar comidas semanales en base a la despensa del usuario y sus recetas disponibles.',
+    );
+
+    if (request.mealType) {
+      sections.push(`Tipo de comida objetivo: ${request.mealType}.`);
+    }
+
+    if (request.targetDate) {
+      sections.push(`Fecha objetivo: ${request.targetDate}.`);
+    }
+
+    if (request.dietary) {
+      const dietaryFlags = Object.entries(request.dietary)
+        .filter(([, value]) => Boolean(value))
+        .map(([key]) => key)
+        .join(', ');
+      if (dietaryFlags) {
+        sections.push(`Restricciones dietéticas: ${dietaryFlags}.`);
+      }
+    }
+
+    if (typeof request.maxTime === 'number') {
+      sections.push(`Tiempo máximo deseado: ${request.maxTime} minutos.`);
+    }
+
+    sections.push('\n### Despensa actual');
+    if (context.pantry.length === 0) {
+      sections.push('- El usuario no tiene ingredientes registrados actualmente.');
+    } else {
+      for (const item of context.pantry) {
+        sections.push(
+          `- ${item.name}${item.quantity ? ` (${item.quantity}${item.unit ? ` ${item.unit}` : ''})` : ''}${item.isFavorite ? ' ⭐' : ''}${item.category ? ` [${item.category}]` : ''}`,
+        );
+      }
+    }
+
+    sections.push('\n### Recetas disponibles');
+    if (context.recipes.length === 0) {
+      sections.push('- No hay recetas guardadas por el usuario.');
+    } else {
+      for (const recipe of context.recipes) {
+        const details: string[] = [];
+        if (recipe.tags?.length) details.push(`tags: ${recipe.tags.join(', ')}`);
+        if (recipe.totalTime) details.push(`tiempo total: ${recipe.totalTime} min`);
+        if (recipe.lastPlannedDate) details.push(`última vez: ${recipe.lastPlannedDate}`);
+        sections.push(`- ${recipe.title}${recipe.isFavorite ? ' ⭐' : ''}${details.length ? ` (${details.join(' | ')})` : ''}`);
+      }
+    }
+
+    sections.push('\n### Planificación actual');
+    if (context.planning.length === 0) {
+      sections.push('- No hay comidas planificadas esta semana.');
+    } else {
+      for (const meal of context.planning) {
+        const label = meal.recipe_id ? `receta ${meal.recipe_id}` : meal.custom_meal_name ?? 'comida personalizada';
+        sections.push(`- ${meal.plan_date} (${meal.meal_type}): ${label}`);
+      }
+    }
+
+    sections.push(
+      `\nGenera hasta ${this.maxSuggestions} sugerencias en formato JSON con la siguiente estructura exacta: { "suggestions": [ { "title": string, "description": string, "reason": string, "id": string opcional, "estimatedTime": string opcional } ] }. Justifica cada sugerencia utilizando la información disponible. Usa español neutro.`,
+    );
+
+    return sections.join('\n');
+  }
+
+  private buildFallbackSuggestions(
+    request: SuggestionRequest,
+    context: SuggestionEngineContext,
+  ): RecipeSuggestion[] {
+    if (context.recipes.length === 0) {
+      return [];
+    }
+
+    const pantryNames = new Set(
+      context.pantry
+        .map((item) => item.name?.toLowerCase())
+        .filter(Boolean) as string[],
+    );
+
+    const ranked = context.recipes
+      .map((recipe) => {
+        const matchCount = recipe.mainIngredients.filter((ingredient) =>
+          pantryNames.has(ingredient.toLowerCase()),
+        ).length;
+
+        const totalTime = recipe.totalTime ?? null;
+        const withinTime =
+          typeof request.maxTime === 'number' && totalTime
+            ? totalTime <= request.maxTime
+            : true;
+
+        const recencyPenalty = this.calculateRecencyPenalty(recipe.lastPlannedDate);
+        let score = matchCount * 2 + (recipe.isFavorite ? 1 : 0);
+        if (!withinTime) {
+          score -= 2;
+        }
+        score -= recencyPenalty;
+
+        return {
+          recipe,
+          score,
+          matchCount,
+          totalTime,
+          withinTime,
+          recencyPenalty,
+        };
+      })
+      .sort((a, b) => b.score - a.score);
+
+    return ranked
+      .slice(0, this.maxSuggestions)
+      .map(({ recipe, matchCount, totalTime, withinTime, recencyPenalty }) => {
+        const reasonParts: string[] = [];
+        if (matchCount > 0) {
+          reasonParts.push(
+            `Aprovecha ${matchCount} ingrediente${matchCount === 1 ? '' : 's'} de tu despensa`,
+          );
+        }
+        if (recipe.isFavorite) {
+          reasonParts.push('Es una de tus recetas favoritas');
+        }
+        if (!recencyPenalty && recipe.lastPlannedDate) {
+          const daysAgo = differenceInCalendarDays(
+            new Date(),
+            new Date(recipe.lastPlannedDate),
+          );
+          if (daysAgo > 7) {
+            reasonParts.push(`Hace ${daysAgo} días que no la preparas`);
+          }
+        }
+        if (!withinTime && typeof request.maxTime === 'number') {
+          reasonParts.push('Requiere más tiempo del deseado');
+        }
+        if (reasonParts.length === 0) {
+          reasonParts.push('Varía tu menú con una opción diferente');
+        }
+
+        return {
+          id: recipe.id,
+          title: recipe.title,
+          description: recipe.description ?? 'Receta guardada en tu biblioteca.',
+          reason: reasonParts.join('. '),
+          estimatedTime: totalTime ? `${totalTime} minutos` : undefined,
+        } satisfies RecipeSuggestion;
+      });
+  }
+
+  private extractRecipeIngredients(ingredients: RecipeIngredient[] | null | undefined): string[] {
+    if (!ingredients?.length) {
+      return [];
+    }
+    return ingredients
+      .map((ingredient) => ingredient?.ingredient_name?.toLowerCase())
+      .filter((name): name is string => Boolean(name));
+  }
+
+  private calculateRecencyPenalty(lastPlannedDate?: string | null): number {
+    if (!lastPlannedDate) {
+      return 0;
+    }
+
+    const daysAgo = differenceInCalendarDays(new Date(), new Date(lastPlannedDate));
+    if (Number.isNaN(daysAgo)) {
+      return 0;
+    }
+
+    if (daysAgo <= 2) {
+      return 3;
+    }
+    if (daysAgo <= 5) {
+      return 1;
+    }
+    return 0;
+  }
+}
+
+export const suggestionEngine = new SuggestionEngine();


### PR DESCRIPTION
## Summary
- add a configurable AI client with mock and proxy providers to centralize model calls
- create a suggestion engine that combines pantry, recipe and planning context before requesting AI suggestions
- build an AI-powered suggestions page behind a feature flag and expose it through the navigation

## Testing
- `npm run build` *(fails: repository currently has 183 pre-existing TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68f299280e108320a8895e5501f13290